### PR TITLE
Feature convert_values_to_numeric is now tested and gets 'except' option

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -103,6 +103,9 @@ module SmarterCSV
         hash.delete_if{|k,v| v =~ options[:remove_values_matching]} if options[:remove_values_matching]
         if options[:convert_values_to_numeric]
           hash.each do |k,v|
+            if options[:convert_values_to_numeric].is_a?(Hash) && options[:convert_values_to_numeric].has_key?(:except)
+              next if Array(options[:convert_values_to_numeric][:except]).include?(k)
+            end
             case v
             when /^[+-]?\d+\.\d+$/
               hash[k] = v.to_f

--- a/spec/fixtures/numeric.csv
+++ b/spec/fixtures/numeric.csv
@@ -1,0 +1,5 @@
+First Name,Last Name,Reference, Wealth
+Dan,McAllister,0123,3.5
+,,,,,
+Miles,O'Brian,2345,3
+Nancy,Homes,2345,01 

--- a/spec/smarter_csv/convert_values_to_numeric_spec.rb
+++ b/spec/smarter_csv/convert_values_to_numeric_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'numeric conversion of values' do
+  it 'occurs by default' do 
+    options = {}
+    data = SmarterCSV.process("#{fixture_path}/numeric.csv", options)
+    data.size.should == 3  
+    
+    # all the keys should be symbols
+    data.each do |hash| 
+      hash[:wealth].should be_a_kind_of(Numeric) unless hash[:wealth].nil? 
+      hash[:reference].should be_a_kind_of(Numeric) unless hash[:reference].nil?
+    end
+  end
+
+  it 'can be prevented for all values' do
+    options = { convert_values_to_numeric: false } 
+    data = SmarterCSV.process("#{fixture_path}/numeric.csv", options)
+    
+    data.each do |hash| 
+      hash[:wealth].should be_a_kind_of(String) unless hash[:wealth].nil? 
+      hash[:reference].should be_a_kind_of(String) unless hash[:reference].nil?
+    end
+  end
+
+  it 'can be prevented for some existing keys' do
+    options = { convert_values_to_numeric: { except: :reference }}
+    data = SmarterCSV.process("#{fixture_path}/numeric.csv", options)
+
+    data.each do |hash| 
+      hash[:wealth].should be_a_kind_of(Numeric) unless hash[:wealth].nil? 
+      hash[:reference].should be_a_kind_of(String) unless hash[:reference].nil?
+    end
+  end
+end


### PR DESCRIPTION
- One can now pass convert_values_to_numeric: { except: [key1,key2] }
- TODO add warning when key in except does not exist in header
