### PR TITLE
Modify Hash.zip implementation and add specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ RSpec::Core::RakeTask.new do |t|
 end
 
 desc "Run specs for all test cases"
-task :spec_all do 
+task :spec_all do
   system "rake spec"
 end
 

--- a/lib/extensions/hash.rb
+++ b/lib/extensions/hash.rb
@@ -2,7 +2,7 @@ class Hash
 
   # Example:
   #     Hash.zip(["a", "b", "c"], [1, 2, 3])
-  #     # => {"a" => 1, "b" => 2, "c" => 3}
+  #     # => { "a" => 1, "b" => 2, "c" => 3 }
   def self.zip(keys, values)
     self[keys.zip(values)]
   end

--- a/lib/extensions/hash.rb
+++ b/lib/extensions/hash.rb
@@ -1,9 +1,9 @@
-# the following extension for class Hash is needed (from Facets of Ruby library):
-
 class Hash
-  def self.zip(keys,values) # from Facets of Ruby library
-    h = {}
-    keys.size.times{ |i| h[ keys[i] ] = values[i] }
-    h
+
+  # Example:
+  #     Hash.zip(["a", "b", "c"], [1, 2, 3])
+  #     # => {"a" => 1, "b" => 2, "c" => 3}
+  def self.zip(keys, values)
+    self[keys.zip(values)]
   end
 end

--- a/spec/smarter_csv/extensions_spec.rb
+++ b/spec/smarter_csv/extensions_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe "Hash.zip" do
+  it "constructs a new Hash from two Arrays" do
+    Hash.zip(["a", "b"], [1, 2]).should == { "a" => 1, "b" => 2 }
+  end
+
+  it "constructs an empty Hash if given no keys" do
+    Hash.zip([], []).should == {}
+    Hash.zip([], [1]).should == {}
+  end
+
+  it "uses nil values if there are more keys than values" do
+    Hash.zip(["a"], []).should == { "a" => nil }
+    Hash.zip(["a", "b"], [1]).should == { "a" => 1, "b" => nil }
+  end
+end


### PR DESCRIPTION
This implementation composes `Hash[]` and `zip()` to avoid mutating a hash. I also added specs.
