### PR TITLE
Add :skip_lines option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea
+

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -9,7 +9,7 @@ module SmarterCSV
       :remove_empty_values => true, :remove_zero_values => false , :remove_values_matching => nil , :remove_empty_hashes => true , :strip_whitespace => true,
       :convert_values_to_numeric => true, :strip_chars_from_headers => nil , :user_provided_headers => nil , :headers_in_file => true,
       :comment_regexp => /^#/, :chunk_size => nil , :key_mapping_hash => nil , :downcase_header => true, :strings_as_keys => false, :file_encoding => 'utf-8',
-      :remove_unmapped_keys => false, :keep_original_headers => false,
+      :remove_unmapped_keys => false, :keep_original_headers => false, :skip_lines => 0
     }
     options = default_options.merge(options)
     csv_options = options.select{|k,v| [:col_sep, :row_sep, :quote_char].include?(k)} # options.slice(:col_sep, :row_sep, :quote_char)
@@ -25,6 +25,10 @@ module SmarterCSV
         f.rewind
       end
       $/ = options[:row_sep]
+
+      if options[:skip_lines].to_i > 0
+        options[:skip_lines].to_i.times{f.readline}
+      end
 
       if options[:headers_in_file]        # extract the header line
         # process the header line in the CSV file..

--- a/spec/fixtures/skip_lines.csv
+++ b/spec/fixtures/skip_lines.csv
@@ -1,0 +1,8 @@
+Lines
+To
+Skip
+first name,last name,dogs,cats,birds,fish
+Dan,McAllister,2,,,
+Lucy,Laweless,,5,,
+Miles,O'Brian,,,,21
+Nancy,Homes,2,,1,

--- a/spec/smarter_csv/skip_lines_spec.rb
+++ b/spec/smarter_csv/skip_lines_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'be_able_to' do
+  it 'loads_csv_file_skipping_lines' do
+    options = {skip_lines: 3}
+    data = SmarterCSV.process("#{fixture_path}/skip_lines.csv", options)
+    data.size.should == 4
+
+    data.each do |item|
+      item.keys.each do |key|
+        [:first_name,:last_name,:dogs,:cats,:birds,:fish].should include(key)
+      end
+    end
+  end
+
+  it 'loads_csv_with_user_defined_headers' do
+    options = {:skip_lines => 3, :headers_in_file => true, :user_provided_headers => [:a,:b,:c,:d,:e,:f]}
+    data = SmarterCSV.process("#{fixture_path}/skip_lines.csv", options)
+    data.size.should == 4
+  
+    data.each do |item|
+      item.keys.each do |key|
+        [:a,:b,:c,:d,:e,:f].should include( key )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a :skip_lines => N option that will skip the first N lines of a CSV file before starting to process. 

This is useful for CSV files that contain summary or other data before the main CSV data.
