### PR TITLE
Feature Request: Exposing invalid byte sequence errors in UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The options and the block are optional.
      |                             |          |      also accepts either {:except => [:key1,:key2]} or {:only => :key3}              |
      | :remove_empty_hashes        |   true   | remove / ignore any hashes which don't have any key/value pairs                      |
      | :file_encoding              |   utf-8  | Set the file encoding eg.: 'windows-1252' or 'iso-8859-1'                            |
+     | :invalid_byte_sequence      |   ?      | Set the replacer for invalid byte sequence when :file_encoding is set to utf-8       |
      | :force_simple_split         |   false  | force simiple splitting on :col_sep character for non-standard CSV-files.            |
      |                             |          | e.g. when :quote_char is not properly escaped                                        |
      | :verbose                    |   false  | print out line number while processing (to track down problems in input files)       |

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -217,7 +217,7 @@ module SmarterCSV
     filehandle.each_char do |c|
       quoted_char = !quoted_char if c == options[:quote_char]
                              # Skip invalid byte sequence in UTF-8
-      next if quoted_char || begin c !~ /\r|\n|\r\n/ rescue false end
+      next if quoted_char || begin c !~ /\r|\n|\r\n/ rescue true end
       counts[c] += 1
     end
     # find the key/value pair with the largest counter:

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -9,7 +9,7 @@ module SmarterCSV
       :remove_empty_values => true, :remove_zero_values => false , :remove_values_matching => nil , :remove_empty_hashes => true , :strip_whitespace => true,
       :convert_values_to_numeric => true, :strip_chars_from_headers => nil , :user_provided_headers => nil , :headers_in_file => true,
       :comment_regexp => /^#/, :chunk_size => nil , :key_mapping_hash => nil , :downcase_header => true, :strings_as_keys => false, :file_encoding => 'utf-8',
-      :remove_unmapped_keys => false, :keep_original_headers => false,
+      :remove_unmapped_keys => false, :keep_original_headers => false, :invalid_byte_sequence => '?'
     }
     options = default_options.merge(options)
     csv_options = options.select{|k,v| [:col_sep, :row_sep, :quote_char].include?(k)} # options.slice(:col_sep, :row_sep, :quote_char)
@@ -86,6 +86,8 @@ module SmarterCSV
       # now on to processing all the rest of the lines in the CSV file:
       while ! f.eof?    # we can't use f.readlines() here, because this would read the whole file into memory at once, and eof => true
         line = f.readline  # read one line.. this uses the input_record_separator $/ which we set previously!
+        # replace invalid byte sequence in UTF-8 with question mark to avoid errors
+        line = line.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: options[:invalid_byte_sequence]) if options[:file_encoding] == 'utf-8'
         line_count += 1
         print "processing line %10d\r" % line_count if options[:verbose]
         next  if  line =~ options[:comment_regexp]  # ignore all comment lines if there are any
@@ -214,7 +216,8 @@ module SmarterCSV
     # ignoring those contained within quote characters
     filehandle.each_char do |c|
       quoted_char = !quoted_char if c == options[:quote_char]
-      next if quoted_char || c !~ /\r|\n|\r\n/
+                             # Skip invalid byte sequence in UTF-8
+      next if quoted_char || begin c !~ /\r|\n|\r\n/ rescue false end
       counts[c] += 1
     end
     # find the key/value pair with the largest counter:


### PR DESCRIPTION
Checking and replacing invalid byte sequence when :file_encoding => 'utf-8'.
Added option :invalid_byte_sequence to set replacing character.
