### PR TITLE
Remove Unused Regex

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -37,7 +37,6 @@ module SmarterCSV
         else
           file_headerA =  header.split(options[:col_sep])
         end
-        file_headerA.map!{|x| x.gsub(%r/options[:quote_char]/,'') }
         file_headerA.map!{|x| x.strip}  if options[:strip_whitespace]
         unless options[:keep_original_headers]
           file_headerA.map!{|x| x.gsub(/\s+|-+/,'_')}
@@ -107,7 +106,6 @@ module SmarterCSV
         else
           dataA =  line.split(options[:col_sep])
         end
-        dataA.map!{|x| x.gsub(%r/options[:quote_char]/,'') }
         dataA.map!{|x| x.strip}  if options[:strip_whitespace]
         hash = Hash.zip(headerA,dataA)  # from Facets of Ruby library
         # make sure we delete any key/value pairs from the hash, which the user wanted to delete:

--- a/spec/fixtures/quote_char.csv
+++ b/spec/fixtures/quote_char.csv
@@ -1,0 +1,9 @@
+"ID","FIRST_NAME","LAST_NAME"
+"1","""John","Cooke"""
+"2","Jam
+e
+son""","McCollum"
+"3","""Jean","Conn"
+"4","Jenny","Traer"
+"5","Bo""bbie","Faga"
+"6","Mica","Copeland"

--- a/spec/smarter_csv/quote_char_spec.rb
+++ b/spec/smarter_csv/quote_char_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'be able to' do
+  it 'remove quotes from quoted fields' do
+    options = {}
+    data = SmarterCSV.process("#{fixture_path}/quote_char.csv", options)
+
+    expect(data.length).to eql(6)
+    expect(data[1][:first_name]).to eql("Jam\ne\nson\"")
+    expect(data[2][:first_name]).to eql("\"Jean")
+  end
+end


### PR DESCRIPTION
While digging into some issues I had with quoted csv I discovered a few
regex expressions which weren't being interpolated. I wrote a test
around the different varieties of double quoted strings and removed
these lines to save a few maps.
