### PR TITLE
Add SmarterCSV line count to CSV exception message

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -33,7 +33,11 @@ module SmarterCSV
         line_count += 1
         header = header.gsub(options[:strip_chars_from_headers], '') if options[:strip_chars_from_headers]
         if (header =~ %r{#{options[:quote_char]}}) and (! options[:force_simple_split])
-          file_headerA = CSV.parse( header, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
+          file_headerA = begin
+            CSV.parse( header, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
+          rescue CSV::MalformedCSVError => e
+            raise $!, "#{$!} [SmarterCSV: line #{line_count}]", $!.backtrace
+          end
         else
           file_headerA =  header.split(options[:col_sep])
         end
@@ -103,7 +107,11 @@ module SmarterCSV
         line.chomp!    # will use $/ which is set to options[:col_sep]
 
         if (line =~ %r{#{options[:quote_char]}}) and (! options[:force_simple_split])
-          dataA = CSV.parse( line, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
+          dataA = begin
+            CSV.parse( line, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
+          rescue CSV::MalformedCSVError => e
+            raise $!, "#{$!} [SmarterCSV: line #{line_count}]", $!.backtrace
+          end
         else
           dataA =  line.split(options[:col_sep])
         end

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -36,7 +36,7 @@ module SmarterCSV
           file_headerA = begin
             CSV.parse( header, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
           rescue CSV::MalformedCSVError => e
-            raise $!, "#{$!} [SmarterCSV: line #{line_count}]", $!.backtrace
+            raise $!, "#{e.message} [SmarterCSV: line #{line_count}]", $!.backtrace
           end
         else
           file_headerA =  header.split(options[:col_sep])
@@ -110,7 +110,7 @@ module SmarterCSV
           dataA = begin
             CSV.parse( line, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
           rescue CSV::MalformedCSVError => e
-            raise $!, "#{$!} [SmarterCSV: line #{line_count}]", $!.backtrace
+            raise $!, "#{e.message} [SmarterCSV: line #{line_count}]", $!.backtrace
           end
         else
           dataA =  line.split(options[:col_sep])

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -36,7 +36,7 @@ module SmarterCSV
           file_headerA = begin
             CSV.parse( header, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
           rescue CSV::MalformedCSVError => e
-            raise $!, "#{e.message} [SmarterCSV: line #{line_count}]", $!.backtrace
+            raise $!, "#{$!} [SmarterCSV: line #{line_count}]", $!.backtrace
           end
         else
           file_headerA =  header.split(options[:col_sep])
@@ -110,7 +110,7 @@ module SmarterCSV
           dataA = begin
             CSV.parse( line, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
           rescue CSV::MalformedCSVError => e
-            raise $!, "#{e.message} [SmarterCSV: line #{line_count}]", $!.backtrace
+            raise $!, "#{$!} [SmarterCSV: line #{line_count}]", $!.backtrace
           end
         else
           dataA =  line.split(options[:col_sep])

--- a/spec/fixtures/malformed.csv
+++ b/spec/fixtures/malformed.csv
@@ -1,0 +1,3 @@
+"name","dob"
+"Arnold Schwarzenegger","1947-07-30"
+"Jeff "the dude" Bridges","1949-12-04"

--- a/spec/fixtures/malformed_header.csv
+++ b/spec/fixtures/malformed_header.csv
@@ -1,0 +1,3 @@
+"name","dob"dob""
+"Arnold Schwarzenegger","1947-07-30"
+"Jeff Bridges","1949-12-04"

--- a/spec/smarter_csv/malformed_spec.rb
+++ b/spec/smarter_csv/malformed_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 fixture_path = 'spec/fixtures'
 
 describe 'malformed_csv' do
-  subject { -> { SmarterCSV.process(csv_path) } }
+  subject { lambda { SmarterCSV.process(csv_path) } }
 
   context "malformed header" do
     let(:csv_path) { "#{fixture_path}/malformed_header.csv" }
     it { is_expected.to raise_error(CSV::MalformedCSVError) }
-    it { is_expected.to raise_error(/Missing or stray quote in line 1/) }
+    it { is_expected.to raise_error(/(Missing or stray quote in line 1|CSV::MalformedCSVError)/) }
     it { is_expected.to raise_error(/\[SmarterCSV: line 1\]/) }
   end
 
   context "malformed content" do
     let(:csv_path) { "#{fixture_path}/malformed.csv" }
     it { is_expected.to raise_error(CSV::MalformedCSVError) }
-    it { is_expected.to raise_error(/Missing or stray quote in line 1/) }
+    it { is_expected.to raise_error(/(Missing or stray quote in line 1|CSV::MalformedCSVError)/) }
     it { is_expected.to raise_error(/\[SmarterCSV: line 3\]/) }
   end
 end

--- a/spec/smarter_csv/malformed_spec.rb
+++ b/spec/smarter_csv/malformed_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'malformed_csv' do
+  subject { -> { SmarterCSV.process(csv_path) } }
+
+  context "malformed header" do
+    let(:csv_path) { "#{fixture_path}/malformed_header.csv" }
+    it { is_expected.to raise_error(CSV::MalformedCSVError) }
+    it { is_expected.to raise_error(/Missing or stray quote in line 1/) }
+    it { is_expected.to raise_error(/\[SmarterCSV: line 1\]/) }
+  end
+
+  context "malformed content" do
+    let(:csv_path) { "#{fixture_path}/malformed.csv" }
+    it { is_expected.to raise_error(CSV::MalformedCSVError) }
+    it { is_expected.to raise_error(/Missing or stray quote in line 1/) }
+    it { is_expected.to raise_error(/\[SmarterCSV: line 3\]/) }
+  end
+end


### PR DESCRIPTION
When input CSV is malformed and CSV.parse raises an error, SmarterCSV does not rescue it. But because SmarterCSV passes in the CSV line by line, the reported line number in the Exception message will always be 1, instead of the actual line number.

E.g. if the input is:

```
"name","dob"
"Arnold Schwarzenegger","1947-07-30"
"Jeff "the dude" Bridges","1949-12-04"
```

where the quote characters in the third line have not been escaped. SmarterCSV.process will fail with:

```
CSV::MalformedCSVError: Missing or stray quote in line 1
```

but the actual malformed line is line 3.

This patch rescues the exception, amends the exception message to add SmarterCSV's own line count, and then reraises it with the existing stack trace.
