### PR TITLE
Improve verbose during process

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -92,7 +92,7 @@ module SmarterCSV
         line = f.readline  # read one line.. this uses the input_record_separator $/ which we set previously!
         file_line_count += 1
         csv_line_count += 1
-        print "processing file line %10d, csv line %10d\r" % file_line_count, csv_line_count if options[:verbose]
+        print "processing file line %10d, csv line %10d\r" % [file_line_count, csv_line_count] if options[:verbose]
         next  if  line =~ options[:comment_regexp]  # ignore all comment lines if there are any
 
         # cater for the quoted csv data containing the row separator carriage return character
@@ -105,7 +105,7 @@ module SmarterCSV
         while line.count(options[:quote_char])%2 == 1
           line += f.readline
           file_line_count += 1
-          print "line contains uneven number of quote chars so including content of file line %10d\n" % (file_line_count) if options[:verbose]
+          print "line contains uneven number of quote chars so including content of file line %10d\n" % file_line_count if options[:verbose]
         end
 
         line.chomp!    # will use $/ which is set to options[:col_sep]

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -16,7 +16,8 @@ module SmarterCSV
     headerA = []
     result = []
     old_row_sep = $/
-    line_count = 0
+    file_line_count = 0
+    csv_line_count = 0
     begin
       f = input.respond_to?(:readline) ? input : File.open(input, "r:#{options[:file_encoding]}")
 
@@ -30,7 +31,8 @@ module SmarterCSV
         # process the header line in the CSV file..
         # the first line of a CSV file contains the header .. it might be commented out, so we need to read it anyhow
         header = f.readline.sub(options[:comment_regexp],'').chomp(options[:row_sep])
-        line_count += 1
+        file_line_count += 1
+        csv_line_count += 1
         header = header.gsub(options[:strip_chars_from_headers], '') if options[:strip_chars_from_headers]
         if (header =~ %r{#{options[:quote_char]}}) and (! options[:force_simple_split])
           file_headerA = CSV.parse( header, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
@@ -88,16 +90,22 @@ module SmarterCSV
       # now on to processing all the rest of the lines in the CSV file:
       while ! f.eof?    # we can't use f.readlines() here, because this would read the whole file into memory at once, and eof => true
         line = f.readline  # read one line.. this uses the input_record_separator $/ which we set previously!
-        line_count += 1
-        print "processing line %10d\r" % line_count if options[:verbose]
+        file_line_count += 1
+        csv_line_count += 1
+        print "processing file line %10d, csv line %10d\r" % file_line_count, csv_line_count if options[:verbose]
         next  if  line =~ options[:comment_regexp]  # ignore all comment lines if there are any
 
         # cater for the quoted csv data containing the row separator carriage return character
         # in which case the row data will be split across multiple lines (see the sample content in spec/fixtures/carriage_returns_rn.csv)
         # by detecting the existence of an uneven number of quote characters
+        if line.count(options[:quote_char])%2 == 1
+          # print new line to retain last processing line message
+          print "\n" if options[:verbose]
+        end
         while line.count(options[:quote_char])%2 == 1
-          print "line contains uneven number of quote chars so including content of next line" if options[:verbose]
           line += f.readline
+          file_line_count += 1
+          print "line contains uneven number of quote chars so including content of file line %10d\n" % (file_line_count) if options[:verbose]
         end
 
         line.chomp!    # will use $/ which is set to options[:col_sep]
@@ -176,6 +184,10 @@ module SmarterCSV
           end
         end
       end
+
+      # print new line to retain last processing line message
+      print "\n" if options[:verbose]
+
       # last chunk:
       if ! chunk.nil? && chunk.size > 0
         # do something with the chunk

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -105,7 +105,7 @@ module SmarterCSV
         while line.count(options[:quote_char])%2 == 1
           line += f.readline
           file_line_count += 1
-          print "line contains uneven number of quote chars so including content of file line %10d\n" % file_line_count if options[:verbose]
+          print "line contains uneven number of quote chars so including content of file line %d\n" % file_line_count if options[:verbose]
         end
 
         line.chomp!    # will use $/ which is set to options[:col_sep]

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -98,15 +98,12 @@ module SmarterCSV
         # cater for the quoted csv data containing the row separator carriage return character
         # in which case the row data will be split across multiple lines (see the sample content in spec/fixtures/carriage_returns_rn.csv)
         # by detecting the existence of an uneven number of quote characters
-        if line.count(options[:quote_char])%2 == 1
-          # print new line to retain last processing line message
-          print "\n" if options[:verbose]
-        end
+        multiline = line.count(options[:quote_char])%2 == 1
         while line.count(options[:quote_char])%2 == 1
           line += f.readline
           file_line_count += 1
-          print "line contains uneven number of quote chars so including content of file line %d\n" % file_line_count if options[:verbose]
         end
+        print "\nline contains uneven number of quote chars so including content through file line %d\n" % file_line_count if options[:verbose] && multiline
 
         line.chomp!    # will use $/ which is set to options[:col_sep]
 


### PR DESCRIPTION
Verbose print statements are overwritten by other print statements making debug difficult. Changed this by adding new lines and separate counts for read file lines and processed csv lines.

```
processing file line          2, csv line          2
line contains uneven number of quote chars so including content of file line 3
processing file line          4, csv line          3
```
