### PR TITLE
Fix: raise error if there are no headers in the input file and…

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -48,7 +48,7 @@ module SmarterCSV
 
         file_header_size = file_headerA.size
       else
-        raise SmarterCSV::IncorrectOption , "ERROR [smarter_csv]: If :headers_in_file is set to false, you have to provide :user_provided_headers" if ! options.keys.include?(:user_provided_headers)
+        raise SmarterCSV::IncorrectOption , "ERROR [smarter_csv]: If :headers_in_file is set to false, you have to provide :user_provided_headers" if options[:user_provided_headers].nil?
       end
       if options[:user_provided_headers] && options[:user_provided_headers].class == Array && ! options[:user_provided_headers].empty?
         # use user-provided headers
@@ -245,4 +245,3 @@ module SmarterCSV
     return k                    # the most frequent one is it
   end
 end
-


### PR DESCRIPTION
…user did not provide headers.

The old condition `! options.keys.include?(:user_provided_headers)` never returns true because the options hash is at this point merged with the default options and thus always contains the key `:user_provided_headers`.
