### PR TITLE
Remove trailing slash from link to Jack article

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ NOTE: If you use `key_mappings` and `value_converters`, make sure that the value
       => Float
 
 ## Parallel Processing
-[Jack](https://github.com/xjlin0) wrote an interesting article about [Speeding up CSV parsing with parallel processing](http://xjlin0.github.io/tech/2015/05/25/faster-parsing-csv-with-parallel-processing/)
+[Jack](https://github.com/xjlin0) wrote an interesting article about [Speeding up CSV parsing with parallel processing](http://xjlin0.github.io/tech/2015/05/25/faster-parsing-csv-with-parallel-processing)
 
 ## Documentation
 


### PR DESCRIPTION
The readme link to the article by Jack throws a "Sorry this page does not exist =(" error when including a trailing slash. Removing the slash fixes the problem. 

Found the issue by clicking the link in the readme and getting an error page. Googled for the article and found it. Compared the two urls and found only variance was the trailing slash. Tried it both ways in Chrome and Safari and it resolves the issue.