### PR TITLE
Travis: Build matrix trimmer, all builds pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,20 @@
 language: ruby
 bundler_args: --without development
-rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1.3
-  - 2.2.2
-  - jruby
-  - ruby-head
-  - jruby-head
-  - ree
-  - rbx
-# jdk:
-#   - oraclejdk7
-#   - openjdk7
-env: JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
+before_install:
+  - gem install bundler
+  - gem update --system
+
 matrix:
-  allow_failures:
-    - rbx
-    - rvm: jruby-head
+  include:
+    - rvm: 2.1.10
+    - rvm: 2.2.6
+    - rvm: 2.3.3
+    - rvm: 2.4.0
+    - rvm: jruby-9.1.8.0
+      env:
+        - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head
-    - rvm: ree
-    - rvm: 1.8.7
-    - rvm: jruby-18mode
+
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 
-gem "rake"
+gem "rake", "< 11"
 
 group :test do
-  gem "rspec", "~> 2.14"
+  gem "rspec", "~> 2.99"
 end

--- a/README.md
+++ b/README.md
@@ -261,10 +261,6 @@ The options and the block are optional.
  * some CSV files use un-escaped quotation characters inside fields. This can cause the import to break. To get around this, use the `:force_simple_split => true` option in combination with `:strip_chars_from_headers => /[\-"]/` . This will also significantly speed up the import.
    If you would force a different :quote_char instead (setting it to a non-used character), then the import would be up to 5-times slower than using `:force_simple_split`.
 
-#### Known Issues:
- * if you are using 1.8.7 versions of Ruby, JRuby, or Ruby Enterprise Edition, `smarter_csv` will have problems with double-quoted fields, because of a bug in an underlying library.
-
-
 ## See also:
 
   http://www.unixgods.org/~tilo/Ruby/process_csv_as_hashes.html


### PR DESCRIPTION
This PR changes the **build matrix** to include latest stable JRuby and MRI releases.

It also removes from the matrix Rubies that do not work with SmarterCsv. See the comments below for details about what kinds of incompatibilities there are.

Also, it makes sure all Rubies _build green_ 💚 

- This issue https://github.com/ruby/rake/issues/116 is worked around with a combination of using 2.99 of RSpec and < 11 of Rake.
- All the specific version numbers are taken from the list at https://github.com/rbenv/ruby-build/tree/master/share/ruby-build 