### PR TITLE
Don't mutate the passed in options

### DIFF
--- a/lib/smarter_csv/options_processing.rb
+++ b/lib/smarter_csv/options_processing.rb
@@ -124,32 +124,32 @@ module SmarterCSV
     if requested_header_transformations.to_s == 'none'
       requested_header_transformations = []
     else
-      requested_header_transformations.reject!{|x| x.to_s == 'none'} unless requested_header_transformations.nil?
+      requested_header_transformations = requested_header_transformations.reject {|x| x.to_s == 'none'} unless requested_header_transformations.nil?
     end
     if requested_header_validations.to_s == 'none'
       requested_header_validations = []
     else
-      requested_header_validations.reject!{|x| x.to_s == 'none'} unless requested_header_validations.nil?
+      requested_header_validations = requested_header_validations.reject {|x| x.to_s == 'none'} unless requested_header_validations.nil?
     end
     if requested_data_transformations.to_s == 'none'
       requested_data_transformations = []
     else
-      requested_data_transformations.reject!{|x| x.to_s == 'none'} unless requested_data_transformations.nil?
+      requested_data_transformations = requested_data_transformations.reject {|x| x.to_s == 'none'} unless requested_data_transformations.nil?
     end
     if requested_data_validations.to_s == 'none'
       requested_data_validations = []
     else
-      requested_data_validations.reject!{|x| x.to_s == 'none'} unless requested_data_validations.nil?
+      requested_data_validations = requested_data_validations.reject {|x| x.to_s == 'none'} unless requested_data_validations.nil?
     end
     if requested_hash_transformations.to_s == 'none'
       requested_hash_transformations = []
     else
-      requested_hash_transformations.reject!{|x| x.to_s == 'none'} unless requested_hash_transformations.nil?
+      requested_hash_transformations = requested_hash_transformations.reject {|x| x.to_s == 'none'} unless requested_hash_transformations.nil?
     end
     if requested_hash_validations.to_s == 'none'
       requested_hash_validations = []
     else
-      requested_hash_validations.reject!{|x| x.to_s == 'none'} unless requested_hash_validations.nil?
+      requested_hash_validations = requested_hash_validations.reject {|x| x.to_s == 'none'} unless requested_hash_validations.nil?
     end
     # now append the user-defined validations / transformations:
     default_options[:header_transformations] += (requested_header_transformations || [])


### PR DESCRIPTION
When an options hash is reused in parsing multiple files, the reject! destructive call will alter the header_transformations list in such a way that it'd go from [:none, :do_something_on_headers, :keys_as_symbols] to [:keys_as_symbols, :do_something_on_headers, :keys_as_symbols] after the first call to SmarterCSV.process.  In general, we shouldn't alter passed in arguments unless explicitly documented as a in-out param.