### PR TITLE
Travis: use jruby-9.1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - rvm: 2.3.6
     - rvm: 2.4.3
     - rvm: 2.5.0
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/04/23/jruby-9-1-17-0.html