### PR TITLE
unifying Fixnum into Integer changing ruby 2.4

### DIFF
--- a/spec/smarter_csv/binary_file_spec.rb
+++ b/spec/smarter_csv/binary_file_spec.rb
@@ -23,7 +23,12 @@ describe 'loads binary file format with comments' do
       # all keys should be symbols when using v1.x backwards compatible mode
       item.keys.each{|x| x.class.should eq Symbol}
       item[:timestamp].should eq 1381388409
-      item[:item_id].class.should eq Fixnum
+      # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+      if 0.class == Integer
+        item[:item_id].class.should eq Integer
+      else
+        item[:item_id].class.should eq Fixnum
+      end
       item[:name].size.should be > 0
     end
     data[3][:parent_id].should be_nil
@@ -67,7 +72,12 @@ describe 'loads binary file format with comments' do
       # all keys should be strings
       item.keys.each{|x| x.class.should eq String}
       item['timestamp'].should eq 1381388409
-      item['item_id'].class.should eq Fixnum
+      # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+      if 0.class == Integer
+        item['item_id'].class.should eq Integer
+      else
+        item['item_id'].class.should eq Fixnum
+      end
       item['name'].size.should be > 0
     end
     data[3]['parent_id'].should be_nil
@@ -91,7 +101,12 @@ describe 'loads binary file format with comments' do
       # all keys should be symbols
       item.keys.each{|x| x.class.should eq Symbol}
       item[:timestamp].should eq 1381388409
-      item[:item_id].class.should eq Fixnum
+      # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+      if 0.class == Integer
+        item[:item_id].class.should eq Integer
+      else
+        item[:item_id].class.should eq Fixnum
+      end
       item[:name].size.should be > 0
     end
     data[3][:parent_id].should be_nil

--- a/spec/smarter_csv/quoted_spec.rb
+++ b/spec/smarter_csv/quoted_spec.rb
@@ -47,7 +47,12 @@ describe 'loading file with quoted fields' do
     data[2][:model].should eq 'Venture "Extended Edition, Very Large"'
     data[2][:description].should be_nil
     data.each do |h|
-      h[:year].class.should eq Fixnum
+      # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+      if 0.class == Integer
+        h[:year].class.should eq Integer
+      else
+        h[:year].class.should eq Fixnum
+      end
       h[:make].should_not be_nil
       h[:model].should_not be_nil
       h[:price].class.should eq Float

--- a/spec/smarter_csv/trading_spec.rb
+++ b/spec/smarter_csv/trading_spec.rb
@@ -14,10 +14,16 @@ describe 'loads simple file format' do
     data.each do |item|
       # all keys should be symbols when using v1.x backwards compatible mode
       item.keys.each{|x| x.class.should eq Symbol}
-      item[:account_id].class.should eq Fixnum
+      # Ruby 2.4+ unifies Fixnum & Bignum into Integer.
+      if 0.class == Integer
+        item[:account_id].class.should eq Integer
+        item[:shares_issued].class.should eq Integer
+      else
+        item[:account_id].class.should eq Fixnum
+        item[:shares_issued].class.should eq Fixnum
+      end
       item[:options_trader].class.should eq String
       item[:stock_symbol].class.should eq String
-      item[:shares_issued].class.should eq Fixnum
       item[:purchase_date].class.should eq String
     end
   end


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer: 
https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/

Running rspec in Ruby >= 2.4, ```warning: constant ::Fixnum is deprecated``` message appeared.
I modified considering backward compatibility (Ruby >= 2.2).