### PR TITLE
Use Exceptions decending from StandardError

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -1,11 +1,11 @@
 
 module SmarterCSV
-
-  class HeaderSizeMismatch < Exception; end
-  class IncorrectOption < Exception; end
-  class DuplicateHeaders < Exception; end
-  class MissingHeaders < Exception; end
-  class ObsoleteOptions < Exception; end
+  class SmarterCSVException < StandardError; end
+  class HeaderSizeMismatch < SmarterCSVException; end
+  class IncorrectOption < SmarterCSVException; end
+  class DuplicateHeaders < SmarterCSVException; end
+  class MissingHeaders < SmarterCSVException; end
+  class ObsoleteOptions < SmarterCSVException; end
 
   def self.errors
     @errors


### PR DESCRIPTION
Normal exceptions should be subclasses of StandardError so that they
are caught by 'catch => e' etc.

https://robots.thoughtbot.com/rescue-standarderror-not-exception gives some more info on this.