### PR TITLE
Fix issue from multiline expectation when using force_simple_plit

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -182,14 +182,16 @@ module SmarterCSV
         # cater for the quoted csv data containing the row separator carriage return character
         # in which case the row data will be split across multiple lines (see the sample content in spec/fixtures/carriage_returns_rn.csv)
         # by detecting the existence of an uneven number of quote characters
-        multiline = line.count(options[:quote_char])%2 == 1
-        while line.count(options[:quote_char])%2 == 1
-          next_line = f.readline
-          next_line = next_line.force_encoding('utf-8').encode('utf-8', invalid: :replace, undef: :replace, replace: options[:invalid_byte_sequence]) if options[:force_utf8] || options[:file_encoding] !~ /utf-8/i
-          line += next_line
-          @file_line_count += 1
+        unless options[:force_simple_split]
+          multiline = line.count(options[:quote_char])%2 == 1
+          while line.count(options[:quote_char])%2 == 1
+            next_line = f.readline
+            next_line = next_line.force_encoding('utf-8').encode('utf-8', invalid: :replace, undef: :replace, replace: options[:invalid_byte_sequence]) if options[:force_utf8] || options[:file_encoding] !~ /utf-8/i
+            line += next_line
+            @file_line_count += 1
+          end
+          print "\nline contains uneven number of quote chars so including content through file line %d\n" % @file_line_count if options[:verbose] && multiline
         end
-        print "\nline contains uneven number of quote chars so including content through file line %d\n" % @file_line_count if options[:verbose] && multiline
 
         line.chomp!    # will use $/ which is set to options[:col_sep]
         next if line.empty? || line =~ /\A\s*\z/

--- a/spec/fixtures/unescaped_quotes.csv
+++ b/spec/fixtures/unescaped_quotes.csv
@@ -1,0 +1,4 @@
+Make;Model;Description
+Ford;;"ac, "abs", moon"
+Chevy;Venture "Extended Edition"";""
+Jeep";Grand "Cherokee;

--- a/spec/smarter_csv/force_simple_split_spec.rb
+++ b/spec/smarter_csv/force_simple_split_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'process badly quoted CSV files' do
+
+  let!(:options) { { col_sep: ';', force_simple_split: true } }
+
+  context 'with single-line raw data CSV file' do
+    it 'processes the file ignoring unescaped quotes' do
+      data = SmarterCSV.process("#{fixture_path}/unescaped_quotes.csv", options)
+
+      data[0][:make].should eq 'Ford'
+      data[0][:model].should eq nil
+      data[0][:description].should eq '"ac, "abs", moon"'
+      data[1][:make].should eq 'Chevy'
+      data[1][:model].should eq 'Venture "Extended Edition""'
+      data[1][:description].should eq '""'
+      data[2][:make].should eq 'Jeep"'
+      data[2][:model].should eq 'Grand "Cherokee'
+      data[2][:description].should eq nil
+    end
+  end
+end


### PR DESCRIPTION
I ran into this issue while processing poorly quoted, non standard CSV files with odd numbers of unescaped quotes found in the CSV lines. So I used the `force_simple_split: true` option to process those files (the column separator character is ";", so its working very well since there is almost no chance I encounter the ";" character in the data itself).

The problem is that the count of quotes (`options[:quote_char]`) is used to detect multi-lines row data. This is working for well quoted CSV files but not for a non-standard CSV files with odd quote's number that will be processed with the option `force_simple_split: true`. Because of that, the core code detects a multi-line row data and I get the following error when processing the files : 

```
EOFError:
       end of file reached
     # ./lib/smarter_csv/smarter_csv.rb:188:in `readline'
     # ./lib/smarter_csv/smarter_csv.rb:188:in `process'
```

I added a test case so you can reproduce the error.

I'm fully aware that this is not a perfect solution since it would be impossible to process multi-line row data files with force_simple_split to true. But in my opinion using the `force_simple_split` option means you can't rely on quote to parse the file. That's why I'm proposing this quick (but effective !) fix.