### PR TITLE
Travis: update matrix patch versions, add 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ before_install:
 
 matrix:
   include:
-    - rvm: 2.2.9
-    - rvm: 2.3.6
-    - rvm: 2.4.3
-    - rvm: 2.5.0
-    - rvm: jruby-9.2.0.0
+    - rvm: 2.2.10
+    - rvm: 2.3.8
+    - rvm: 2.4.5
+    - rvm: 2.5.3
+    - rvm: 2.6.0
+    - rvm: jruby-9.2.5.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

Adds 2.6.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)