### PR TITLE
CI: use 2.4.6, 2.5.5, 2.6.3, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - rvm: 2.3.8
     - rvm: 2.4.6
     - rvm: 2.5.5
-    - rvm: 2.6.2
+    - rvm: 2.6.3
     - rvm: jruby-9.2.7.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: ruby
 bundler_args: --without development
-before_install:
-  - gem install bundler
-  - gem update --system
 
 matrix:
   include:
     - rvm: 2.2.10
     - rvm: 2.3.8
     - rvm: 2.4.5
-    - rvm: 2.5.3
-    - rvm: 2.6.1
+    - rvm: 2.5.5
+    - rvm: 2.6.2
     - rvm: jruby-9.2.6.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
   include:
     - rvm: 2.2.10
     - rvm: 2.3.8
-    - rvm: 2.4.5
+    - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.2
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ matrix:
     - rvm: 2.3.8
     - rvm: 2.4.5
     - rvm: 2.5.3
-    - rvm: 2.6.0
-    - rvm: jruby-9.2.5.0
+    - rvm: 2.6.1
+    - rvm: jruby-9.2.6.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)