### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.3
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2.9.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - rvm: 2.4.6
     - rvm: 2.5.5
     - rvm: 2.6.3
-    - rvm: jruby-9.2.7.0
+    - rvm: jruby-9.2.8.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.9.0**.

[JRuby 9.2.9.0 release blog post](https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html)