### PR TITLE
Fix deprecation warning on Ruby 2.7

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -78,7 +78,7 @@ module SmarterCSV
 
         if (header =~ %r{#{options[:quote_char]}}) and (! options[:force_simple_split])
           file_headerA = begin
-            CSV.parse( header, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
+            CSV.parse( header, **csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
           rescue CSV::MalformedCSVError => e
             raise $!, "#{$!} [SmarterCSV: csv line #{@csv_line_count}]", $!.backtrace
           end
@@ -196,7 +196,7 @@ module SmarterCSV
 
         if (line =~ %r{#{options[:quote_char]}}) and (! options[:force_simple_split])
           dataA = begin
-            CSV.parse( line, csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
+            CSV.parse( line, **csv_options ).flatten.collect!{|x| x.nil? ? '' : x} # to deal with nil values from CSV.parse
           rescue CSV::MalformedCSVError => e
             raise $!, "#{$!} [SmarterCSV: csv line #{@csv_line_count}]", $!.backtrace
           end


### PR DESCRIPTION
After upgrading my local environment to Ruby 2.7.1, I started getting deprecation warnings like this:

```
/***/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/smarter_csv-1.2.6/lib/smarter_csv/smarter_csv.rb:152: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/***/.rbenv/versions/2.7.1/lib/ruby/2.7.0/csv.rb:679: warning: The called method `parse' is defined here
```

This PR just fixes the method call so that the deprecation warning disappears. 