### PR TITLE
CI: Use JRuby 9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.6.6
     - rvm: 2.7.2
     - rvm: 3.0.0
-    - rvm: jruby-9.2.12.0
+    - rvm: jruby-9.2.15.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.6.6
     - rvm: 2.7.2
     - rvm: 3.0.0
-    - rvm: jruby-9.2.15.0
+    - rvm: jruby-9.2.16.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)