### PR TITLE
CI: Use latest JRuby 9.2.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.6.6
     - rvm: 2.7.2
     - rvm: 3.0.0
-    - rvm: jruby-9.2.18.0
+    - rvm: jruby-9.2.19.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.6.6
     - rvm: 2.7.2
     - rvm: 3.0.0
-    - rvm: jruby-9.2.16.0
+    - rvm: jruby-9.2.17.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rvm: 2.6.6
     - rvm: 2.7.2
     - rvm: 3.0.0
-    - rvm: jruby-9.2.17.0
+    - rvm: jruby-9.2.18.0
       env:
         - JRUBY_OPTS="--server -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -J-Xms512m -J-Xmx1024m"
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.19.0**.

[JRuby 9.2.19.0 release blog post](https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html)