### PR TITLE
Add missing keys to the `SmarterCSV::KeyMappingError` exception message

### DIFF
--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -378,7 +378,8 @@ module SmarterCSV
       #   if you want to completely delete a key, then map it to nil or to ''
       if ! key_mappingH.nil? && key_mappingH.class == Hash && key_mappingH.keys.size > 0
         # we can't map keys that are not there
-        raise SmarterCSV::KeyMappingError unless (key_mappingH.keys - headerA).empty?
+        missing_keys = key_mappingH.keys - headerA
+        raise(SmarterCSV::KeyMappingError, "missing header(s): #{missing_keys.join(",")}") unless missing_keys.empty?
 
         headerA.map!{|x| key_mappingH.has_key?(x) ? (key_mappingH[x].nil? ? nil : key_mappingH[x]) : (options[:remove_unmapped_keys] ? nil : x)}
       end

--- a/spec/smarter_csv/duplicate_headers_spec.rb
+++ b/spec/smarter_csv/duplicate_headers_spec.rb
@@ -17,12 +17,12 @@ describe 'duplicate headers' do
       }.to raise_exception(SmarterCSV::DuplicateHeaders)
     end
 
-    it 'raises error on missing mapped headers' do
+    it 'raises error on missing mapped headers and includes missing headers in message' do
       expect {
         # the mapping is right, but the underlying csv file is bad
         options = {:key_mapping => {:email => :a, :firstname => :b, :lastname => :c, :manager_email => :d, :age => :e} }
         SmarterCSV.process("#{fixture_path}/duplicate_headers.csv", options)
-      }.to raise_exception(SmarterCSV::KeyMappingError)
+      }.to raise_exception(SmarterCSV::KeyMappingError, "missing header(s): manager_email")
     end
   end
 

--- a/spec/smarter_csv/invalid_headers_spec.rb
+++ b/spec/smarter_csv/invalid_headers_spec.rb
@@ -28,11 +28,11 @@ describe 'test exceptions for invalid headers' do
     }.to raise_exception(SmarterCSV::MissingHeaders)
   end
 
-  it 'raises error on missing mapped headers' do
+  it 'raises error on missing mapped headers and includes missing headers in message' do
     expect {
       # :age does not exist in the CSV header
       options = {:key_mapping => {:email => :a, :firstname => :b, :lastname => :c, :manager_email => :d, :age => :e} }
       SmarterCSV.process("#{fixture_path}/user_import.csv", options)
-    }.to raise_exception(SmarterCSV::KeyMappingError)
+    }.to raise_exception(SmarterCSV::KeyMappingError, "missing header(s): age")
   end
 end


### PR DESCRIPTION
Prior to version 1.4, I was able to identify missing headers, but with recent changes that added `SmarterCSV::KeyMappingError` I can no longer identify what is missing.  This PR attempts to make that information available in the exception message.

This capability is very helpful in my use case where we have users uploading CSV files that they create.  This helps them more easily identify issues with the file.