### PR TITLE
Migrate Simplecov call to spec_helper

### DIFF
--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -1,9 +1,3 @@
-require 'simplecov'
-SimpleCov.start do
-  add_filter "/spec/"
-  add_filter "/pkg/"
-end
-
 require 'csv'
 require "smarter_csv/version"
 require "core_ext/hash"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
 require 'rubygems'
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+  add_filter "/pkg/"
+end
+
 require 'bundler/setup'
 
 Bundler.require(:default)


### PR DESCRIPTION
When I add `smarter_csv` to Gemfile in my rails project, and start the rails server, I get the following error:

```
/bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require': cannot load such file -- simplecov (LoadError)
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require'
        from /bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/dependencies.rb:332:in `block in require'
        from /bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/dependencies.rb:299:in `load_dependency'
        from /bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/dependencies.rb:332:in `require'
        from /bundle/ruby/3.0.0/bundler/gems/smarter_csv-3e83010c4c70/lib/smarter_csv.rb:1:in `<main>'
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /usr/local/lib/ruby/3.0.0/bundler/runtime.rb:60:in `block (2 levels) in require'
        from /usr/local/lib/ruby/3.0.0/bundler/runtime.rb:55:in `each'
        from /usr/local/lib/ruby/3.0.0/bundler/runtime.rb:55:in `block in require'
        from /usr/local/lib/ruby/3.0.0/bundler/runtime.rb:44:in `each'
        from /usr/local/lib/ruby/3.0.0/bundler/runtime.rb:44:in `require'
        from /usr/local/lib/ruby/3.0.0/bundler.rb:175:in `require'
        from /eyan/config/application.rb:8:in `<main>'
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/dependencies.rb:332:in `block in require'
        from /bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/dependencies.rb:299:in `load_dependency'
        from /bundle/ruby/3.0.0/gems/activesupport-6.1.4.4/lib/active_support/dependencies.rb:332:in `require'
        from /bundle/ruby/3.0.0/gems/railties-6.1.4.4/lib/rails/commands/server/server_command.rb:138:in `block in perform'
        from <internal:kernel>:90:in `tap'
        from /bundle/ruby/3.0.0/gems/railties-6.1.4.4/lib/rails/commands/server/server_command.rb:135:in `perform'
        from /bundle/ruby/3.0.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /bundle/ruby/3.0.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /bundle/ruby/3.0.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /bundle/ruby/3.0.0/gems/railties-6.1.4.4/lib/rails/command/base.rb:69:in `perform'
        from /bundle/ruby/3.0.0/gems/railties-6.1.4.4/lib/rails/command.rb:48:in `invoke'
        from /bundle/ruby/3.0.0/gems/railties-6.1.4.4/lib/rails/commands.rb:18:in `<main>'
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from /bundle/ruby/3.0.0/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        from bin/rails:13:in `<main>'
```

My Rails project doesn't use simplecov, so it seems unable to require `simplecov`.

How about requiring it in `spec_helper`?