### PR TITLE
Add `silence_missing_keys` option to ignore missing keys in `key_mappping`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # SmarterCSV 1.x Change Log
 
+## 1.7.3 (2022-12-05)
+  * new option :silence_missing_keys; if set to true, it ignores missing keys in `key_mapping`
+
 ## 1.7.2 (2022-08-29)
   * new option :with_line_numbers; if set to true, it adds :csv_line_number to each data hash (issue #130)
   

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The options and the block are optional.
      |                             |          | You can not combine the :user_provided_headers and :key_mapping options              |
      | :remove_empty_hashes        |   true   | remove / ignore any hashes which don't have any key/value pairs or all empty values  |
      | :verbose                    |   false  | print out line number while processing (to track down problems in input files)       |
-     | :with_line_numbers          |   false  | add :csv_line_number to heach data hash                                              |
+     | :with_line_numbers          |   false  | add :csv_line_number to each data hash                                               |
      ---------------------------------------------------------------------------------------------------------------------------------
 
 #### Deprecated 1.x Options: to be replaced in 2.0
@@ -253,7 +253,8 @@ And header and data validations will also be supported in 2.x
      | Option                      | Default  |  Explanation                                                                         |
      ---------------------------------------------------------------------------------------------------------------------------------
      | :key_mapping                |   nil    | a hash which maps headers from the CSV file to keys in the result hash               |
-     | :required_headers           |   nil    | An array. Eacn of the given headers must be present after header manipulation,       |
+     | :silence_missing_key        |   false  | ignore missing keys in `key_mapping` if true                                         |
+     | :required_headers           |   nil    | An array. Each of the given headers must be present after header manipulation,       |
      |                             |          | or an exception is raised   No validation if nil is given.                           |
      | :remove_unmapped_keys       |   false  | when using :key_mapping option, should non-mapped keys / columns be removed?         |
      | :downcase_header            |   true   | downcase all column headers                                                          |

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -227,6 +227,7 @@ module SmarterCSV
         remove_zero_values: false,
         required_headers: nil,
         row_sep: $/,
+        silence_missing_keys: false,
         skip_lines: nil,
         strings_as_keys: false,
         strip_chars_from_headers: nil,
@@ -479,9 +480,11 @@ module SmarterCSV
         # do some key mapping on the keys in the file header
         #   if you want to completely delete a key, then map it to nil or to ''
         if !key_mappingH.nil? && key_mappingH.class == Hash && key_mappingH.keys.size > 0
-          # we can't map keys that are not there
-          missing_keys = key_mappingH.keys - headerA
-          puts "WARNING: missing header(s): #{missing_keys.join(",")}" unless missing_keys.empty?
+          unless options[:silence_missing_keys]
+            # if silence_missing_keys are not set, raise error if missing header
+            missing_keys = key_mappingH.keys - headerA
+            puts "WARNING: missing header(s): #{missing_keys.join(",")}" unless missing_keys.empty?
+          end
 
           headerA.map!{|x| key_mappingH.has_key?(x) ? (key_mappingH[x].nil? ? nil : key_mappingH[x]) : (options[:remove_unmapped_keys] ? nil : x)}
         end

--- a/lib/smarter_csv/version.rb
+++ b/lib/smarter_csv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SmarterCSV
-  VERSION = "1.7.2"
+  VERSION = "1.7.3"
 end

--- a/spec/fixtures/silence_missing_keys.csv
+++ b/spec/fixtures/silence_missing_keys.csv
@@ -1,0 +1,2 @@
+THIS,THAT
+this,that

--- a/spec/smarter_csv/silence_missing_keys.rb
+++ b/spec/smarter_csv/silence_missing_keys.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'be_able_to' do
+  it 'throws_error_if_missing_keys_by_default' do
+    options = {key_mapping: {THIS: :this, missing_key: :that}}
+    expect { SmarterCSV.process("#{fixture_path}/silence_missing_keys.csv", options) }.to raise_error
+  end
+
+  it 'loads_csv_without_missing_keys_if_silence_missing_keys_is_set' do
+    options = {silence_missing_keys: true, key_mapping: {THIS: :this, missing_key: :that}}
+    data = SmarterCSV.process("#{fixture_path}/silence_missing_keys.csv", options)
+    expect(data.size).to eq 1
+    data.each do |item|
+      item.each_key do |key|
+        expect(key.class).to eq Symbol # all the keys should be symbols
+        expect(%i[this THAT]).to include(key)
+      end
+    end
+  end
+end


### PR DESCRIPTION
New option `silence_missing_keys` that ignores missing keys in `key_mapping` if set to true.