### PR TITLE
validate options / 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # SmarterCSV 1.x Change Log
 
 ## 1.8.1 (2023-03-19)
-  * protection against invalid values for :col_sep, :row_sep, :quote_char (issue #216)
+  * added validation against invalid values for :col_sep, :row_sep, :quote_char (issue #216)
   * deprecating `required_headers` and replace with `required_keys` (issue #140)
   * fixed issue with require statement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # SmarterCSV 1.x Change Log
 
+## 1.8.1 (2023-03-20)
+  * protection against invalid values for :col_sep, :row_sep, :quote_char (issue #216)
+
 ## 1.8.0 (2023-03-18)
   * NEW DEFAULTS: `col_sep: :auto`, `row_sep: :auto`. Fully automatic detection by default.
   * ignore Byte Order Marker (BOM) in first line in file (issues #27, #219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## 1.8.1 (2023-03-20)
   * protection against invalid values for :col_sep, :row_sep, :quote_char (issue #216)
+  * deprecating `required_headers` and replace with `required_keys` (issue #140)
 
 ## 1.8.0 (2023-03-18)
   * NEW DEFAULTS: `col_sep: :auto`, `row_sep: :auto`. Fully automatic detection by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 
 # SmarterCSV 1.x Change Log
 
-## 1.8.1 (2023-03-20)
+## 1.8.1 (2023-03-19)
   * protection against invalid values for :col_sep, :row_sep, :quote_char (issue #216)
   * deprecating `required_headers` and replace with `required_keys` (issue #140)
+  * fixed issue with require statement
 
 ## 1.8.0 (2023-03-18)
   * NEW DEFAULTS: `col_sep: :auto`, `row_sep: :auto`. Fully automatic detection by default.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ And header and data validations will also be supported in 2.x
      ---------------------------------------------------------------------------------------------------------------------------------
      | :key_mapping                |   nil    | a hash which maps headers from the CSV file to keys in the result hash               |
      | :silence_missing_key        |   false  | ignore missing keys in `key_mapping` if true                                         |
-     | :required_headers           |   nil    | An array. Each of the given headers must be present after header manipulation,       |
+     | :required_headers           |   nil    | An array. Specify the required names AFTER header transformation.                  |
      |                             |          | or an exception is raised   No validation if nil is given.                           |
      | :remove_unmapped_keys       |   false  | when using :key_mapping option, should non-mapped keys / columns be removed?         |
      | :downcase_header            |   true   | downcase all column headers                                                          |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ $ hexdump -C spec/fixtures/bom_test_feff.csv
 00000040  73 2c 35 36 37 38 0d 0a                           |s,5678..|
 ```
 
+### Examples
+
+Here are some examples to demonstrate the versatility of SmarterCSV.
+
+By default SmarterCSV determines the `row_sep` and `col_sep` values automatically.
+In rare cases you may have to manually set these values, after going through the troubleshooting procedure described above.
 
 #### Example 1a: How SmarterCSV processes CSV-files as array of hashes:
 Please note how each hash contains only the keys for columns with non-null values.

--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ And header and data validations will also be supported in 2.x
      ---------------------------------------------------------------------------------------------------------------------------------
      | :key_mapping                |   nil    | a hash which maps headers from the CSV file to keys in the result hash               |
      | :silence_missing_key        |   false  | ignore missing keys in `key_mapping` if true                                         |
-     | :required_headers           |   nil    | An array. Specify the required names AFTER header transformation.                  |
+     | :required_keys              |   nil    | An array. Specify the required names AFTER header transformation.                  |
+     | :required_headers           |   nil    | (DEPRECATED / renamed) Use `required_keys` instead                          |
      |                             |          | or an exception is raised   No validation if nil is given.                           |
      | :remove_unmapped_keys       |   false  | when using :key_mapping option, should non-mapped keys / columns be removed?         |
      | :downcase_header            |   true   | downcase all column headers                                                          |

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -27,7 +27,6 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
     long col_sep_len = RSTRING_LEN(col_sep);
 
     char *quoteP = RSTRING_PTR(quote_char);
-    long quote_len = RSTRING_LEN(quote_char);
     long quote_count = 0;
 
     bool col_sep_found = true;

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -14,8 +14,7 @@ module SmarterCSV
   class DuplicateHeaders < SmarterCSVException; end
   class MissingHeaders < SmarterCSVException; end
   class NoColSepDetected < SmarterCSVException; end
-  class KeyMappingError < SmarterCSVException; end
-  class MalformedCSVError < SmarterCSVException; end
+  class KeyMappingError < SmarterCSVException; end # CURRENTLY UNUSED -> version 1.9.0
 
   # first parameter: filename or input object which responds to readline method
   def SmarterCSV.process(input, options = {}, &block)

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -4,7 +4,7 @@ require_relative "extensions/hash"
 require_relative "smarter_csv/version"
 
 require_relative "smarter_csv/smarter_csv" unless ENV['CI'] # does not compile/link in CI?
-# require 'smarter_csv.bundle' unless ENV['CI'] # does not compile/link in CI?
+# require 'smarter_csv.bundle' unless ENV['CI'] # local testing
 
 module SmarterCSV
   class SmarterCSVException < StandardError; end

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -3,8 +3,8 @@
 require_relative "extensions/hash"
 require_relative "smarter_csv/version"
 
-# require_relative "smarter_csv/smarter_csv" unless ENV['CI'] # does not compile/link in CI?
-require 'smarter_csv.bundle' unless ENV['CI'] # does not compile/link in CI?
+require_relative "smarter_csv/smarter_csv" unless ENV['CI'] # does not compile/link in CI?
+# require 'smarter_csv.bundle' unless ENV['CI'] # does not compile/link in CI?
 
 module SmarterCSV
   class SmarterCSVException < StandardError; end

--- a/lib/smarter_csv/version.rb
+++ b/lib/smarter_csv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SmarterCSV
-  VERSION = "1.8.0"
+  VERSION = "1.8.1"
 end

--- a/spec/fixtures/required_headers.csv
+++ b/spec/fixtures/required_headers.csv
@@ -1,0 +1,4 @@
+name,count
+Bill,3
+Tom, 2
+Mike,5 

--- a/spec/smarter_csv/basic_spec.rb
+++ b/spec/smarter_csv/basic_spec.rb
@@ -65,7 +65,7 @@ fixture_path = 'spec/fixtures'
         it 'raises an exception if the number of user_provided_headers is incorrect' do
           expect do
             SmarterCSV.process("#{fixture_path}/basic.csv", options)
-          end.to raise_error(SmarterCSV::HeaderSizeMismatch)
+          end.to raise_exception(SmarterCSV::HeaderSizeMismatch)
         end
       end
     end

--- a/spec/smarter_csv/invalid_headers_spec.rb
+++ b/spec/smarter_csv/invalid_headers_spec.rb
@@ -6,26 +6,26 @@ fixture_path = 'spec/fixtures'
 
 describe 'test exceptions for invalid headers' do
   it 'does not raise an error if no required headers are given' do
-    options = {required_headers: nil} # order does not matter
+    options = {required_keys: nil} # order does not matter
     data = SmarterCSV.process("#{fixture_path}/user_import.csv", options)
     expect(data.size).to eq 2
   end
 
   it 'does not raise an error if no required headers are given' do
-    options = {required_headers: []} # order does not matter
+    options = {required_keys: []} # order does not matter
     data = SmarterCSV.process("#{fixture_path}/user_import.csv", options)
     expect(data.size).to eq 2
   end
 
   it 'does not raise an error if the required headers are present' do
-    options = {required_headers: %i[lastname email firstname manager_email]} # order does not matter
+    options = {required_keys: %i[lastname email firstname manager_email]} # order does not matter
     data = SmarterCSV.process("#{fixture_path}/user_import.csv", options)
     expect(data.size).to eq 2
   end
 
   it 'raises an error if a required header is missing' do
     expect do
-      options = {required_headers: %i[lastname email employee_id firstname manager_email]} # order does not matter
+      options = {required_keys: %i[lastname email employee_id firstname manager_email]} # order does not matter
       SmarterCSV.process("#{fixture_path}/user_import.csv", options)
     end.to raise_exception(SmarterCSV::MissingHeaders)
   end
@@ -36,5 +36,27 @@ describe 'test exceptions for invalid headers' do
     expect do
       SmarterCSV.process("#{fixture_path}/user_import.csv", options)
     end.not_to raise_exception
+  end
+
+
+  # TO BE FIXED:
+  #
+  # this raises:  SmarterCSV::MissingHeaders: RROR: missing attributes: middle_name
+  # but instead, the printed WARNING message for missing_keys should raise KeyMappingError
+  #
+  describe 'exception for missing keys / header names' do
+    let(:options) do
+      {
+        required_keys: [:middle_name],
+        key_mapping: { missing_key: :middle_name},
+      }
+    end
+    subject(:data) { SmarterCSV.process("#{fixture_path}/user_import.csv", options) }
+
+    # slated for version 1.9.0
+    xit 'complains about the original header name when source of key_mapping is missing' do
+      expect(SmarterCSV).to receive(:puts).with a_string_matching(/WARNING.*missing_key/)
+      expect{ data }.to raise_exception(SmarterCSV::KeyMappingError)
+    end
   end
 end

--- a/spec/smarter_csv/key_mapping_spec.rb
+++ b/spec/smarter_csv/key_mapping_spec.rb
@@ -4,7 +4,24 @@ require 'spec_helper'
 
 fixture_path = 'spec/fixtures'
 
-describe 'be_able_to' do
+describe 'key_mapping' do
+  describe 'exception for missing keys / header names' do
+    let(:options) { {} }
+    subject(:data) { SmarterCSV.process("#{fixture_path}/basic.csv", options) }
+
+    it 'complains about the original header name when source of key_mapping is missing' do
+      options[:key_mapping] = {missing_key: :something_new}
+      expect(SmarterCSV).to receive(:puts).with a_string_matching(/WARNING.*missing_key/)
+      data
+    end
+
+    # slated for version 1.9.0
+    xit 'raises exception because source of key_mapping is missing' do
+      options[:key_mapping] = {missing_key: :something_new}
+      expect{ data }.to raise_exception(SmarterCSV::KeyMappingError)
+    end
+  end
+
   it 'remove_values_matching' do
     options = {remove_zero_values: true, key_mapping: {first_name: :vorname, last_name: :nachname} }
     data = SmarterCSV.process("#{fixture_path}/basic.csv", options)

--- a/spec/smarter_csv/required_headers_spec.rb
+++ b/spec/smarter_csv/required_headers_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'required_headers' do
+  let(:options) { {} }
+  subject(:data) { SmarterCSV.process("#{fixture_path}/required_headers.csv", options) }
+
+  it 'loads the csv file without issues' do
+    expect(data.size).to eq 3
+    expect(data[0][:name]).to eq 'Bill'
+  end
+
+  it 'uses the attribute name after header transformation' do
+    options[:key_mapping] = {name: :first_name}
+    options[:required_headers] = [:first_name]
+    expect(data.size).to eq 3
+    expect(data[0][:first_name]).to eq 'Bill'
+  end
+
+  it 'raises an exception if the raw header name is used' do
+    options[:key_mapping] = {name: :first_name}
+    options[:required_headers] = [:name]
+    expect{ data }.to raise_error(SmarterCSV::MissingHeaders)
+  end
+end

--- a/spec/smarter_csv/required_headers_spec.rb
+++ b/spec/smarter_csv/required_headers_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 fixture_path = 'spec/fixtures'
 
-describe 'required_headers' do
+describe 'required_headers -> required_keys' do
   let(:options) { {} }
   subject(:data) { SmarterCSV.process("#{fixture_path}/required_headers.csv", options) }
 
@@ -13,16 +13,49 @@ describe 'required_headers' do
     expect(data[0][:name]).to eq 'Bill'
   end
 
-  it 'uses the attribute name after header transformation' do
-    options[:key_mapping] = {name: :first_name}
-    options[:required_headers] = [:first_name]
-    expect(data.size).to eq 3
-    expect(data[0][:first_name]).to eq 'Bill'
+  describe 'with deprecated required_headers' do
+    before do
+      options[:key_mapping] = {name: :first_name}
+    end
+
+    it 'uses the attribute name after header transformation' do
+      options[:required_headers] = [:first_name]
+      expect(data.size).to eq 3
+      expect(data[0][:first_name]).to eq 'Bill'
+    end
+
+    it 'raises an exception if the raw header name is used' do
+      options[:required_headers] = [:name]
+      expect{ data }.to raise_error(SmarterCSV::MissingHeaders)
+    end
+
+    it 'prints a deprecation warning when required_headers is used' do
+      options[:required_headers] = [:first_name]
+      expect(SmarterCSV).to receive(:puts).with a_string_matching(/DEPRECATION WARNING/)
+      data
+    end
   end
 
-  it 'raises an exception if the raw header name is used' do
-    options[:key_mapping] = {name: :first_name}
-    options[:required_headers] = [:name]
-    expect{ data }.to raise_error(SmarterCSV::MissingHeaders)
+  describe 'with deprecated required_keys' do
+    before do
+      options[:key_mapping] = {name: :first_name}
+    end
+
+    it 'uses the attribute name after header transformation' do
+      options[:required_keys] = [:first_name]
+      expect(data.size).to eq 3
+      expect(data[0][:first_name]).to eq 'Bill'
+    end
+
+    it 'raises an exception if the raw header name is used' do
+      options[:required_keys] = [:name]
+      expect{ data }.to raise_error(SmarterCSV::MissingHeaders)
+    end
+
+    it 'does not print a deprecation warning when required_keys is used' do
+      options[:required_keys] = [:first_name]
+      expect(SmarterCSV).not_to receive(:puts).with a_string_matching(/DEPRECATION WARNING/)
+      data
+    end
   end
 end

--- a/spec/smarter_csv/required_headers_spec.rb
+++ b/spec/smarter_csv/required_headers_spec.rb
@@ -26,7 +26,7 @@ describe 'required_headers -> required_keys' do
 
     it 'raises an exception if the raw header name is used' do
       options[:required_headers] = [:name]
-      expect{ data }.to raise_error(SmarterCSV::MissingHeaders)
+      expect{ data }.to raise_exception(SmarterCSV::MissingHeaders)
     end
 
     it 'prints a deprecation warning when required_headers is used' do
@@ -49,7 +49,7 @@ describe 'required_headers -> required_keys' do
 
     it 'raises an exception if the raw header name is used' do
       options[:required_keys] = [:name]
-      expect{ data }.to raise_error(SmarterCSV::MissingHeaders)
+      expect{ data }.to raise_exception(SmarterCSV::MissingHeaders)
     end
 
     it 'does not print a deprecation warning when required_keys is used' do

--- a/spec/smarter_csv/validations_spec.rb
+++ b/spec/smarter_csv/validations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'validations' do
+  let(:options) { {} }
+
+  it 'loads basic csv file without issues' do
+    data = SmarterCSV.process("#{fixture_path}/basic.csv", options)
+    expect(data.size).to eq 5
+  end
+
+  [:row_sep, :col_sep, :quote_char].each do |opt|
+    [nil, '', :symbol, 1].each do |val|
+      context "with #{opt} set to #{val}" do
+        let(:option) { opt }
+        let(:value) { val }
+        let(:options) { { option => value } }
+
+        it "raises an exception if #{opt} is #{val}" do
+          expect { SmarterCSV.process("#{fixture_path}/basic.csv", options) }.to raise_exception(SmarterCSV::ValidationError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* issue #216 : validate values for `col_sep`, `row_sep`, `quote_char` are valid
* issue #140 : rename `required_headers` => `required_keys`, and deprecate `required_headers`