### PR TITLE
New feature: prevent_csv_injection to nil Macro usage

### DIFF
--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -477,6 +477,12 @@ module SmarterCSV
 
         file_headerA.map!{|x| x.gsub(%r/#{options[:quote_char]}/, '')}
         file_headerA.map!{|x| x.strip} if options[:strip_whitespace]
+
+        file_headerA.map!{|x|
+          x = nil if x.match("[+|=|@|-|\t|\x0A|\x0D].*")
+          x
+        } if options[:prevent_csv_injection]
+
         unless options[:keep_original_headers]
           file_headerA.map!{|x| x.gsub(/\s+|-+/, '_')}
           file_headerA.map!{|x| x.downcase} if options[:downcase_header]

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -18,6 +18,7 @@ module SmarterCSV
 
   # first parameter: filename or input object which responds to readline method
   def SmarterCSV.process(input, options = {}, &block)
+    puts 1
     options = default_options.merge(options)
     options[:invalid_byte_sequence] = '' if options[:invalid_byte_sequence].nil?
     puts "SmarterCSV OPTIONS: #{options.inspect}" if options[:verbose]
@@ -81,8 +82,12 @@ module SmarterCSV
         line.chomp!(options[:row_sep])
 
         dataA, _data_size = parse(line, options, header_size)
-
         dataA.map!{|x| x.strip} if options[:strip_whitespace]
+        puts dataA, _data_size, line
+        dataA.map!{|x|
+        x = nil if x.match("[+|=|@|-|\t|\x0A|\x0D].*")
+        x
+        } if options[:prevent_csv_injection]
 
         # if all values are blank, then ignore this line
         next if options[:remove_empty_hashes] && (dataA.empty? || blank?(dataA))
@@ -230,6 +235,7 @@ module SmarterCSV
         strings_as_keys: false,
         strip_chars_from_headers: nil,
         strip_whitespace: true,
+        prevent_csv_injection: false,
         user_provided_headers: nil,
         value_converters: nil,
         verbose: false,

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -18,7 +18,6 @@ module SmarterCSV
 
   # first parameter: filename or input object which responds to readline method
   def SmarterCSV.process(input, options = {}, &block)
-    puts 1
     options = default_options.merge(options)
     options[:invalid_byte_sequence] = '' if options[:invalid_byte_sequence].nil?
     puts "SmarterCSV OPTIONS: #{options.inspect}" if options[:verbose]
@@ -83,7 +82,7 @@ module SmarterCSV
 
         dataA, _data_size = parse(line, options, header_size)
         dataA.map!{|x| x.strip} if options[:strip_whitespace]
-        puts dataA, _data_size, line
+
         dataA.map!{|x|
         x = nil if x.match("[+|=|@|-|\t|\x0A|\x0D].*")
         x

--- a/spec/fixtures/csv_injection.csv
+++ b/spec/fixtures/csv_injection.csv
@@ -1,0 +1,6 @@
+First Name,Last Name,Age
+John,Doe, =SUM(2*2)
+John,Doe,=SUM(2*2)
+Jon,Doe,+2+1
+Jon,Doe,-2+2
+Jon,Doe,	=SUM(2*2)

--- a/spec/smarter_csv/prevent_csv_injection.rb
+++ b/spec/smarter_csv/prevent_csv_injection.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'handling of additional trailing column separators' do
+  let(:file) { "#{fixture_path}/csv_injection.csv" }
+
+  describe '' do
+    let(:data) { SmarterCSV.process(file, {prevent_csv_injection: true, strip_whitespace: false}) }
+    let(:data_prevent_csv_injection_disabled) { SmarterCSV.process(file, {prevent_csv_injection: false, strip_whitespace: false}) }
+    it 'removes macros safely' do
+      data.each do |x|
+        expect(x[:age]).to be_nil
+      end
+    end
+
+    it 'processing works normally' do
+      data_prevent_csv_injection_disabled.each do |x|
+        expect(x[:age]).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
smarter_csv provides a neat approach to process CSV. One feature that can be useful is to have a feature to process the file for CSV Injection / Macro usage and return a static file. This blocks a wide range of potential exploitation in both Google Sheets and Microsoft Excel after the new version of the csv document is processed by smarter_csv.

I created this feature, tested it out, and also wrote Rspec tests for it. The default option is `false` for everyone.

**References:** 
https://owasp.org/www-community/attacks/CSV_Injection
http://georgemauer.net/2017/10/07/csv-injection.html
https://book.hacktricks.xyz/pentesting-web/formula-doc-latex-injection
https://bishopfox.com/blog/server-side-spreadsheet-injections
