### PR TITLE
Prevent reading long lines on C binding to prevent Denial of Service

### DIFF
--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -18,7 +18,7 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
   }
 
   if (RB_TYPE_P(line, T_STRING) != 1) {
-    return rb_ary_new();
+    rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line has to be a string or nil");
   }
 
   if RSTRING_LEN(line) > 1000000 {

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -17,7 +17,7 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
     return rb_ary_new();
   }
 
-  if (RB_TYPE_P(line, T_STRING) == 0) {
+  if (RB_TYPE_P(line, T_STRING) != 1) {
     return rb_ary_new();
   }
 

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -79,7 +79,6 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
 
   return elements;
 
-  rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line has to be a string or nil");
 }
 
 

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -22,7 +22,7 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
   }
 
   if RSTRING_LEN(line) > 1000000 {
-    return rb_ary_new();
+    rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line is too long");
   }
 
   rb_encoding *encoding = rb_enc_get(line); /* get the encoding from the input line */

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -21,7 +21,7 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
     rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line has to be a string or nil");
   }
 
-  if (RSTRING_LEN(line) > NUM2INT(1000000)) {
+  if (RSTRING_LEN(line) > NUM2INT(1048576)) {
     rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line is too long");
   }
 

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -21,7 +21,7 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
     rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line has to be a string or nil");
   }
 
-  if RSTRING_LEN(line) > 1000000 {
+  if RSTRING_LEN(line) > NUM2INT(1000000) {
     rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line is too long");
   }
 

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -15,62 +15,69 @@
 static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quote_char, VALUE max_size) {
   if (RB_TYPE_P(line, T_NIL) == 1) {
     return rb_ary_new();
-
-  } else if (RB_TYPE_P(line, T_STRING) == 1) {
-    rb_encoding *encoding = rb_enc_get(line); /* get the encoding from the input line */
-    char *startP = RSTRING_PTR(line); /* may not be null terminated */
-    long line_len = RSTRING_LEN(line);
-    char *endP = startP + line_len ; /* points behind the string */
-    char *p = startP;
-
-    char *col_sepP = RSTRING_PTR(col_sep);
-    long col_sep_len = RSTRING_LEN(col_sep);
-
-    char *quoteP = RSTRING_PTR(quote_char);
-    long quote_count = 0;
-
-    bool col_sep_found = true;
-
-    VALUE elements = rb_ary_new();
-    VALUE field;
-    long i;
-
-    while (p < endP) {
-      /* does the remaining string start with col_sep ? */
-      col_sep_found = true;
-      for(i=0; (i < col_sep_len) && (p+i < endP) ; i++) {
-        col_sep_found = col_sep_found && (*(p+i) == *(col_sepP+i));
-      }
-      /* if col_sep was found and we have even quotes */
-      if (col_sep_found && (quote_count % 2 == 0)) {
-        /* if max_size != nil && lements.size >= header_size */
-        if ((max_size != Qnil) && RARRAY_LEN(elements) >= NUM2INT(max_size)) {
-          break;
-        } else {
-          /* push that field with original encoding onto the results */
-          field = rb_enc_str_new(startP, p - startP, encoding);
-          rb_ary_push(elements, field);
-
-          p += col_sep_len;
-          startP = p;
-        }
-      } else {
-        if (*p == *quoteP) {
-          quote_count += 1;
-        }
-        p++;
-      }
-    } /* while */
-
-    /* check if the last part of the line needs to be processed */
-    if ((max_size == Qnil) || RARRAY_LEN(elements) < NUM2INT(max_size)) {
-      /* copy the remaining line as a field with original encoding onto the results */
-      field = rb_enc_str_new(startP, endP - startP, encoding);
-      rb_ary_push(elements, field);
-    }
-
-    return elements;
   }
+
+  if (RB_TYPE_P(line, T_STRING) == 0) {
+    return rb_ary_new();
+  }
+
+  if RSTRING_LEN(line) > 1000000 {
+    return rb_ary_new();
+  }
+
+  rb_encoding *encoding = rb_enc_get(line); /* get the encoding from the input line */
+  char *startP = RSTRING_PTR(line); /* may not be null terminated */
+  long line_len = RSTRING_LEN(line);
+  char *endP = startP + line_len ; /* points behind the string */
+  char *p = startP;
+
+  char *col_sepP = RSTRING_PTR(col_sep);
+  long col_sep_len = RSTRING_LEN(col_sep);
+
+  char *quoteP = RSTRING_PTR(quote_char);
+  long quote_count = 0;
+
+  bool col_sep_found = true;
+
+  VALUE elements = rb_ary_new();
+  VALUE field;
+  long i;
+
+  while (p < endP) {
+    /* does the remaining string start with col_sep ? */
+    col_sep_found = true;
+    for(i=0; (i < col_sep_len) && (p+i < endP) ; i++) {
+      col_sep_found = col_sep_found && (*(p+i) == *(col_sepP+i));
+    }
+    /* if col_sep was found and we have even quotes */
+    if (col_sep_found && (quote_count % 2 == 0)) {
+      /* if max_size != nil && lements.size >= header_size */
+      if ((max_size != Qnil) && RARRAY_LEN(elements) >= NUM2INT(max_size)) {
+        break;
+      } else {
+        /* push that field with original encoding onto the results */
+        field = rb_enc_str_new(startP, p - startP, encoding);
+        rb_ary_push(elements, field);
+
+        p += col_sep_len;
+        startP = p;
+      }
+    } else {
+      if (*p == *quoteP) {
+        quote_count += 1;
+      }
+      p++;
+    }
+  } /* while */
+
+  /* check if the last part of the line needs to be processed */
+  if ((max_size == Qnil) || RARRAY_LEN(elements) < NUM2INT(max_size)) {
+    /* copy the remaining line as a field with original encoding onto the results */
+    field = rb_enc_str_new(startP, endP - startP, encoding);
+    rb_ary_push(elements, field);
+  }
+
+  return elements;
 
   rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line has to be a string or nil");
 }

--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -21,7 +21,7 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
     rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line has to be a string or nil");
   }
 
-  if RSTRING_LEN(line) > NUM2INT(1000000) {
+  if (RSTRING_LEN(line) > NUM2INT(1000000)) {
     rb_raise(rb_eTypeError, "ERROR in SmarterCSV.parse_line: line is too long");
   }
 


### PR DESCRIPTION
There is a possible way to cause potential DoS if a huge CSV line is provided. It's possible to prevent this on `acceleration` mode. It's just an idea, looking forward to your feedback!

I also did minor refactor on the method to stop executing if the line is not considered a string, instead of using an extra nesting, not sure if it's going to function as expected; it's my first time playing with Ruby C.

Thank you! 🙏 