### PR TITLE
Handle escaped quote characters

### DIFF
--- a/ext/smarter_csv/smarter_csv.c
+++ b/ext/smarter_csv/smarter_csv.c
@@ -39,6 +39,8 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
   VALUE field;
   long i;
 
+  char prev_char = '\0'; // Store the previous character for comparison against an escape character
+
   while (p < endP) {
     /* does the remaining string start with col_sep ? */
     col_sep_found = true;
@@ -59,11 +61,13 @@ static VALUE rb_parse_csv_line(VALUE self, VALUE line, VALUE col_sep, VALUE quot
         startP = p;
       }
     } else {
-      if (*p == *quoteP) {
+      if (*p == *quoteP && prev_char != '\\') {
         quote_count += 1;
       }
       p++;
     }
+
+    prev_char = *(p - 1); // Update the previous character
   } /* while */
 
   /* check if the last part of the line needs to be processed */

--- a/spec/fixtures/escaped_quote_char.csv
+++ b/spec/fixtures/escaped_quote_char.csv
@@ -1,0 +1,3 @@
+Content,EscapedName,OtherContent
+"Some content","D\"Angelos","Some More Content"
+"Some content","O\"heard","Some More Content"

--- a/spec/fixtures/escaped_quote_char_2.csv
+++ b/spec/fixtures/escaped_quote_char_2.csv
@@ -1,0 +1,3 @@
+Content,EscapedName,OtherContent
+!Some content!,!D\!Angelos!,!Some More Content!
+!Some content!,!O\!heard!,!Some More Content!

--- a/spec/smarter_csv/escaped_quote_chars_spec.rb
+++ b/spec/smarter_csv/escaped_quote_chars_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+fixture_path = 'spec/fixtures'
+
+describe 'handling files with escaped quote chars' do
+  subject(:data) { SmarterCSV.process(file, options) }
+
+  let(:options) { { acceleration: true } }
+
+  describe ".count_quote_chars" do
+    it "handles escaped characters and regular characters" do
+      expect(SmarterCSV.count_quote_chars("\"No\" \"Escaping\"", "\"")).to eq 4
+      expect(SmarterCSV.count_quote_chars("\"D\\\"Angelos\"", "\"")).to eq 2
+      expect(SmarterCSV.count_quote_chars("\!D\\\!Angelos\!", "\!")).to eq 2
+    end
+  end
+
+  context 'when it is a strangely delimited file' do
+    let(:file) { "#{fixture_path}/escaped_quote_char.csv" }
+
+    it 'loads the csv file without issues' do
+      expect(data[0]).to eq(
+        content: 'Some content',
+        escapedname: "D\\\"Angelos",
+        othercontent: "Some More Content"
+      )
+      expect(data[1]).to eq(
+        content: 'Some content',
+        escapedname: "O\\\"heard",
+        othercontent: "Some More Content"
+      )
+      expect(data.size).to eq 2
+    end
+  end
+
+  context 'when it is a strangely delimited file' do
+    let(:file) { "#{fixture_path}/escaped_quote_char_2.csv" }
+    let(:options) do
+      { quote_char: "!" }
+    end
+
+    it 'loads the csv file without issues' do
+      expect(data[0]).to eq(
+        content: 'Some content',
+        escapedname: "D\\\!Angelos",
+        othercontent: "Some More Content"
+      )
+      expect(data[1]).to eq(
+        content: 'Some content',
+        escapedname: "O\\\!heard",
+        othercontent: "Some More Content"
+      )
+      expect(data.size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
* Currently quote_char only allows escaping using the spec standard of `""`

* If you have a string come through in a csv file that is internally escaped with a backslash (`\"`), it will count the escaped string and not parse it properly

* This updates the line parsing logic in both C and Ruby, and the quote_char counting logic to handle checking for a previous character that is a backslash

This gem already follows the spec (https://datatracker.ietf.org/doc/html/rfc4180#section-2), which is great. But some tools will generate an escaped value of `\"` instead of `""`, so this handles that.