### PR TITLE
frozen options bug

### DIFF
--- a/lib/smarter_csv/options_processing.rb
+++ b/lib/smarter_csv/options_processing.rb
@@ -42,11 +42,12 @@ module SmarterCSV
     def process_options(given_options = {})
       puts "User provided options:\n#{pp(given_options)}\n" if given_options[:verbose]
 
-      # fix invalid input
-      given_options[:invalid_byte_sequence] = '' if given_options[:invalid_byte_sequence].nil?
-
       @options = DEFAULT_OPTIONS.dup.merge!(given_options)
-      puts "Computed options:\n#{pp(@options)}\n" if given_options[:verbose]
+
+      # fix invalid input
+      @options[:invalid_byte_sequence] ||= ''
+
+      puts "Computed options:\n#{pp(@options)}\n" if @options[:verbose]
 
       validate_options!(@options)
       @options

--- a/spec/smarter_csv/options_processing_spec.rb
+++ b/spec/smarter_csv/options_processing_spec.rb
@@ -28,6 +28,12 @@ describe 'options processing' do
       generated_options = SmarterCSV.process_options(invalid_byte_sequence: nil)
       expect(generated_options[:invalid_byte_sequence]).to eq ''
     end
+
+    it 'works with frozen options hash' do
+      options = {chunk_size: 1}.freeze
+      generated_options = SmarterCSV.process_options(options)
+      expect(generated_options[:chunk_size]).to eq 1
+    end
   end
 
   describe '#validate_options!' do


### PR DESCRIPTION
Hey Tilo,

smarter_csv modifies the options hash before dup-ing, which explodes when the options hash is frozen.  This happens, specifically, when setting `invalid_byte_sequence`.  I did a little tidying up while I was at it  🎯 😉 