### PR TITLE
Make SmarterCSV thread-safe

### DIFF
--- a/lib/smarter_csv/auto_detection.rb
+++ b/lib/smarter_csv/auto_detection.rb
@@ -7,8 +7,8 @@ module SmarterCSV
     # If file has headers, then guesses column separator from headers.
     # Otherwise guesses column separator from contents.
     # Raises exception if none is found.
-    def guess_column_separator(filehandle, options)
-      skip_lines(filehandle, options)
+    def guess_column_separator(instance, filehandle, options)
+      skip_lines(instance, filehandle, options)
 
       delimiters = [',', "\t", ';', ':', '|']
 
@@ -17,14 +17,14 @@ module SmarterCSV
       candidates = Hash.new(0)
       count = has_header ? 1 : 5
       count.times do
-        line = readline_with_counts(filehandle, options)
+        line = readline_with_counts(instance, filehandle, options)
         delimiters.each do |d|
           candidates[d] += line.scan(d).count
         end
       rescue EOFError # short files
         break
       end
-      rewind(filehandle)
+      rewind(instance, filehandle)
 
       if candidates.values.max == 0
         # if the header only contains
@@ -37,7 +37,7 @@ module SmarterCSV
     end
 
     # limitation: this currently reads the whole file in before making a decision
-    def guess_line_ending(filehandle, options)
+    def guess_line_ending(instance, filehandle, options)
       counts = {"\n" => 0, "\r" => 0, "\r\n" => 0}
       quoted_char = false
 
@@ -62,7 +62,7 @@ module SmarterCSV
         lines += 1
         break if options[:auto_row_sep_chars] && options[:auto_row_sep_chars] > 0 && lines >= options[:auto_row_sep_chars]
       end
-      rewind(filehandle)
+      rewind(instance, filehandle)
 
       counts["\r"] += 1 if last_char == "\r"
       # find the most frequent key/value pair:

--- a/lib/smarter_csv/file_io.rb
+++ b/lib/smarter_csv/file_io.rb
@@ -4,23 +4,23 @@ module SmarterCSV
   class << self
     protected
 
-    def readline_with_counts(filehandle, options)
+    def readline_with_counts(instance, filehandle, options)
       line = filehandle.readline(options[:row_sep])
-      @file_line_count += 1
-      @csv_line_count += 1
-      line = remove_bom(line) if @csv_line_count == 1
+      instance.file_line_count += 1
+      instance.csv_line_count += 1
+      line = remove_bom(line) if instance.csv_line_count == 1
       line
     end
 
-    def skip_lines(filehandle, options)
+    def skip_lines(instance, filehandle, options)
       options[:skip_lines].to_i.times do
-        readline_with_counts(filehandle, options)
+        readline_with_counts(instance, filehandle, options)
       end
     end
 
-    def rewind(filehandle)
-      @file_line_count = 0
-      @csv_line_count = 0
+    def rewind(instance, filehandle)
+      instance.file_line_count = 0
+      instance.csv_line_count = 0
       filehandle.rewind
     end
 

--- a/lib/smarter_csv/hash_transformations.rb
+++ b/lib/smarter_csv/hash_transformations.rb
@@ -2,7 +2,7 @@
 
 module SmarterCSV
   class << self
-    def hash_transformations(hash, options)
+    def hash_transformations(instance, hash, options)
       # there may be unmapped keys, or keys purposedly mapped to nil or an empty key..
       # make sure we delete any key/value pairs from the hash, which the user wanted to delete:
       remove_empty_values = options[:remove_empty_values] == true
@@ -13,7 +13,7 @@ module SmarterCSV
 
       hash.each_with_object({}) do |(k, v), new_hash|
         next if k.nil? || k == '' || k == :""
-        next if remove_empty_values && (has_rails ? v.blank? : blank?(v))
+        next if remove_empty_values && (instance.has_rails ? v.blank? : blank?(v))
         next if remove_zero_values && v.is_a?(String) && v =~ /^(0+|0+\.0+)$/ # values are Strings
         next if remove_values_matching && v =~ remove_values_matching
 

--- a/lib/smarter_csv/headers.rb
+++ b/lib/smarter_csv/headers.rb
@@ -2,9 +2,9 @@
 
 module SmarterCSV
   class << self
-    def process_headers(filehandle, options)
-      @raw_header = nil # header as it appears in the file
-      @headers = nil # the processed headers
+    def process_headers(instance, filehandle, options)
+      instance.raw_header = nil # header as it appears in the file
+      instance.headers = nil # the processed headers
       header_array = []
       file_header_size = nil
 
@@ -12,10 +12,10 @@ module SmarterCSV
       if options[:headers_in_file] # extract the header line
         # process the header line in the CSV file..
         # the first line of a CSV file contains the header .. it might be commented out, so we need to read it anyhow
-        header_line = @raw_header = readline_with_counts(filehandle, options)
+        header_line = instance.raw_header = readline_with_counts(instance, filehandle, options)
         header_line = preprocess_header_line(header_line, options)
 
-        file_header_array, file_header_size = parse(header_line, options)
+        file_header_array, file_header_size = parse(instance, header_line, options)
 
         file_header_array = header_transformations(file_header_array, options)
 

--- a/lib/smarter_csv/options_processing.rb
+++ b/lib/smarter_csv/options_processing.rb
@@ -42,15 +42,15 @@ module SmarterCSV
     def process_options(given_options = {})
       puts "User provided options:\n#{pp(given_options)}\n" if given_options[:verbose]
 
-      @options = DEFAULT_OPTIONS.dup.merge!(given_options)
+      options = DEFAULT_OPTIONS.dup.merge!(given_options)
 
       # fix invalid input
-      @options[:invalid_byte_sequence] ||= ''
+      options[:invalid_byte_sequence] ||= ''
 
-      puts "Computed options:\n#{pp(@options)}\n" if @options[:verbose]
+      puts "Computed options:\n#{pp(options)}\n" if options[:verbose]
 
-      validate_options!(@options)
-      @options
+      validate_options!(options)
+      options
     end
 
     # NOTE: this is not called when "parse" methods are tested by themselves

--- a/lib/smarter_csv/parse.rb
+++ b/lib/smarter_csv/parse.rb
@@ -7,10 +7,10 @@ module SmarterCSV
     ###
     ### Thin wrapper around C-extension
     ###
-    def parse(line, options, header_size = nil)
+    def parse(instance, line, options, header_size = nil)
       # puts "SmarterCSV.parse OPTIONS: #{options[:acceleration]}" if options[:verbose]
 
-      if options[:acceleration] && has_acceleration?
+      if options[:acceleration] && instance.has_acceleration?
         # :nocov:
         has_quotes = line =~ /#{options[:quote_char]}/
         elements = parse_csv_line_c(line, options[:col_sep], options[:quote_char], header_size)

--- a/lib/smarter_csv/smarter_csv.rb
+++ b/lib/smarter_csv/smarter_csv.rb
@@ -12,12 +12,13 @@ module SmarterCSV
 
   # first parameter: filename or input object which responds to readline method
   def SmarterCSV.process(input, given_options = {}, &block) # rubocop:disable Lint/UnusedMethodArgument
-    initialize_variables
+    instance = initialize_variables
+    self.compatibility_instance = instance # backwards compatibility
 
     options = process_options(given_options)
 
-    @enforce_utf8 = options[:force_utf8] || options[:file_encoding] !~ /utf-8/i
-    @verbose = options[:verbose]
+    instance.enforce_utf8 = options[:force_utf8] || options[:file_encoding] !~ /utf-8/i
+    instance.verbose = options[:verbose]
 
     begin
       fh = input.respond_to?(:readline) ? input : File.open(input, "r:#{options[:file_encoding]}")
@@ -27,24 +28,25 @@ module SmarterCSV
       end
 
       # auto-detect the row separator
-      options[:row_sep] = guess_line_ending(fh, options) if options[:row_sep]&.to_sym == :auto
+      options[:row_sep] = guess_line_ending(instance, fh, options) if options[:row_sep]&.to_sym == :auto
       # attempt to auto-detect column separator
-      options[:col_sep] = guess_column_separator(fh, options) if options[:col_sep]&.to_sym == :auto
+      options[:col_sep] = guess_column_separator(instance, fh, options) if options[:col_sep]&.to_sym == :auto
 
-      skip_lines(fh, options)
+      skip_lines(instance, fh, options)
 
-      @headers, header_size = process_headers(fh, options)
-      @headerA = @headers # @headerA is deprecated, use @headers
+      headers, header_size = process_headers(instance, fh, options)
+      instance.headers = headers
+      instance.header_a = headers # headerA is deprecated, use headers
 
-      puts "Effective headers:\n#{pp(@headers)}\n" if @verbose
+      puts "Effective headers:\n#{pp(instance.headers)}\n" if instance.verbose
 
-      header_validations(@headers, options)
+      header_validations(instance.headers, options)
 
       # in case we use chunking.. we'll need to set it up..
       if options[:chunk_size].to_i > 0
         use_chunks = true
         chunk_size = options[:chunk_size].to_i
-        @chunk_count = 0
+        instance.chunk_count = 0
         chunk = []
       else
         use_chunks = false
@@ -53,12 +55,12 @@ module SmarterCSV
       # now on to processing all the rest of the lines in the CSV file:
       # fh.each_line |line|
       until fh.eof? # we can't use fh.readlines() here, because this would read the whole file into memory at once, and eof => true
-        line = readline_with_counts(fh, options)
+        line = readline_with_counts(instance, fh, options)
 
         # replace invalid byte sequence in UTF-8 with question mark to avoid errors
-        line = enforce_utf8_encoding(line, options) if @enforce_utf8
+        line = enforce_utf8_encoding(line, options) if instance.enforce_utf8
 
-        print "processing file line %10d, csv line %10d\r" % [@file_line_count, @csv_line_count] if @verbose
+        print "processing file line %10d, csv line %10d\r" % [instance.file_line_count, instance.csv_line_count] if instance.verbose
 
         next if options[:comment_regexp] && line =~ options[:comment_regexp] # ignore all comment lines if there are any
 
@@ -69,9 +71,9 @@ module SmarterCSV
 
         while multiline
           next_line = fh.readline(options[:row_sep])
-          next_line = enforce_utf8_encoding(next_line, options) if @enforce_utf8
+          next_line = enforce_utf8_encoding(next_line, options) if instance.enforce_utf8
           line += next_line
-          @file_line_count += 1
+          instance.file_line_count += 1
 
           break if fh.eof? # Exit loop if end of file is reached
 
@@ -79,15 +81,15 @@ module SmarterCSV
         end
 
         # :nocov:
-        if multiline && @verbose
-          print "\nline contains uneven number of quote chars so including content through file line %d\n" % @file_line_count
+        if multiline && instance.verbose
+          print "\nline contains uneven number of quote chars so including content through file line %d\n" % instance.file_line_count
         end
         # :nocov:
 
         line.chomp!(options[:row_sep])
 
         # --- SPLIT LINE & DATA TRANSFORMATIONS ------------------------------------------------------------
-        dataA, _data_size = parse(line, options, header_size)
+        dataA, _data_size = parse(instance, line, options, header_size)
 
         dataA.map!{|x| x.strip} if options[:strip_whitespace]
 
@@ -95,9 +97,9 @@ module SmarterCSV
         next if options[:remove_empty_hashes] && (dataA.empty? || blank?(dataA))
 
         # --- HASH TRANSFORMATIONS ------------------------------------------------------------
-        hash = @headers.zip(dataA).to_h
+        hash = instance.headers.zip(dataA).to_h
 
-        hash = hash_transformations(hash, options)
+        hash = hash_transformations(instance, hash, options)
 
         # --- HASH VALIDATIONS ----------------------------------------------------------------
         # will go here, and be able to:
@@ -108,9 +110,9 @@ module SmarterCSV
 
         next if options[:remove_empty_hashes] && hash.empty?
 
-        puts "CSV Line #{@file_line_count}: #{pp(hash)}" if @verbose == '2' # very verbose setting
+        puts "CSV Line #{instance.file_line_count}: #{pp(hash)}" if instance.verbose == '2' # very verbose setting
         # optional adding of csv_line_number to the hash to help debugging
-        hash[:csv_line_number] = @csv_line_count if options[:with_line_numbers]
+        hash[:csv_line_number] = instance.csv_line_count if options[:with_line_numbers]
 
         # process the chunks or the resulting hash
         if use_chunks
@@ -121,9 +123,9 @@ module SmarterCSV
             if block_given?
               yield chunk # do something with the hashes in the chunk in the block
             else
-              @result << chunk.dup # Append chunk to result (use .dup to keep a copy after we do chunk.clear)
+              instance.result << chunk.dup # Append chunk to result (use .dup to keep a copy after we do chunk.clear)
             end
-            @chunk_count += 1
+            instance.chunk_count += 1
             chunk.clear # re-initialize for next chunk of data
           else
             # the last chunk may contain partial data, which is handled below
@@ -134,13 +136,13 @@ module SmarterCSV
           if block_given?
             yield [hash] # do something with the hash in the block (better to use chunking here)
           else
-            @result << hash
+            instance.result << hash
           end
         end
       end
 
       # print new line to retain last processing line message
-      print "\n" if @verbose
+      print "\n" if instance.verbose
 
       # handling of last chunk:
       if !chunk.nil? && chunk.size > 0
@@ -148,9 +150,9 @@ module SmarterCSV
         if block_given?
           yield chunk # do something with the hashes in the chunk in the block
         else
-          @result << chunk.dup # Append chunk to result (use .dup to keep a copy after we do chunk.clear)
+          instance.result << chunk.dup # Append chunk to result (use .dup to keep a copy after we do chunk.clear)
         end
-        @chunk_count += 1
+        instance.chunk_count += 1
         # chunk = [] # initialize for next chunk of data
       end
     ensure
@@ -158,9 +160,9 @@ module SmarterCSV
     end
 
     if block_given?
-      @chunk_count # when we do processing through a block we only care how many chunks we processed
+      instance.chunk_count # when we do processing through a block we only care how many chunks we processed
     else
-      @result # returns either an Array of Hashes, or an Array of Arrays of Hashes (if in chunked mode)
+      instance.result # returns either an Array of Hashes, or an Array of Arrays of Hashes (if in chunked mode)
     end
   end
 
@@ -181,10 +183,6 @@ module SmarterCSV
       end
 
       count
-    end
-
-    def has_acceleration?
-      @has_acceleration ||= !!defined?(parse_csv_line_c)
     end
 
     protected

--- a/lib/smarter_csv/variables.rb
+++ b/lib/smarter_csv/variables.rb
@@ -1,30 +1,62 @@
 # frozen_string_literal: true
 
+require "forwardable"
+
 module SmarterCSV
-  class << self
-    attr_reader :has_rails, :csv_line_count, :chunk_count, :errors, :file_line_count, :headers, :raw_header, :result, :warnings
-
-    def initialize_variables
-      @has_rails = !!defined?(Rails)
-      @csv_line_count = 0
-      @chunk_count = 0
-      @errors = {}
-      @file_line_count = 0
-      @headerA = []
-      @headers = nil
-      @raw_header = nil # header as it appears in the file
-      @result = []
-      @warnings = {}
-      @enforce_utf8 = false # only set to true if needed (after options parsing)
-    end
-
+  Instance = Struct.new(
+    :has_rails, :csv_line_count, :chunk_count, :errors, :file_line_count, :headers, :raw_header, :result, :warnings,
+    :enforce_utf8, :verbose,
+    :has_acceleration,
+    :header_a, # deprecated
+    keyword_init: true
+  ) do
     # :nocov:
     # rubocop:disable Naming/MethodName
     def headerA
-      warn "Deprecarion Warning: 'headerA' will be removed in future versions. Use 'headders'"
-      @headerA
+      warn "Deprecation Warning: 'headerA' will be removed in future versions. Use 'headers'"
+      header_a
     end
     # rubocop:enable Naming/MethodName
     # :nocov:
+
+    def has_acceleration?
+      has_acceleration
+    end
+  end
+
+  class << self
+    extend Forwardable
+
+    # Backwards compatibility
+    # If anyone was using the instance variables directly on the SmarterCSV module before, they should still be
+    #   able to while also maintaining them in a thread-safe way.
+    def compatibility_instance
+      Thread.current[:smarter_csv_compatibility_instance]
+    end
+
+    def compatibility_instance=(instance)
+      Thread.current[:smarter_csv_compatibility_instance] = instance
+    end
+
+    def_delegators :compatibility_instance,
+      :headers, :raw_header, :result, :errors, :warnings, :csv_line_count, :file_line_count, :chunk_count,
+      :has_rails, :has_acceleration, :has_acceleration?, :enforce_utf8, :verbose
+
+    def initialize_variables
+      Instance.new(
+        has_rails: !!defined?(Rails),
+        csv_line_count: 0,
+        chunk_count: 0,
+        errors: {},
+        file_line_count: 0,
+        header_a: [], # only set to true if needed (after options parsing)
+        headers: nil,
+        raw_header: nil, # header as it appears in the file
+        result: [],
+        warnings: {},
+        enforce_utf8: false,
+        has_acceleration: !!defined?(parse_csv_line_c)
+      )
+    end
   end
 end

--- a/spec/features/threading_spec.rb
+++ b/spec/features/threading_spec.rb
@@ -12,6 +12,42 @@ describe 'thread safety checks' do
     }
   }
 
+  let(:correct_chunk_counts) {
+    {
+      'basic.csv' => 3,
+      'simple_with_header.csv' => 2,
+      'emoji.csv' => 2,
+      'quoted.csv' => 2
+    }
+  }
+
+  let(:correct_headers) {
+    {
+      'basic.csv' => [:first_name, :last_name, :dogs, :cats, :birds, :fish],
+      'simple_with_header.csv' => [:user_id],
+      'emoji.csv' => [:first_name, :last_name, :purchases, :score],
+      'quoted.csv' => [:year, :make, :model, :description, :price]
+    }
+  }
+
+  let(:correct_raw_headers) {
+    {
+      'basic.csv' => "First Name,Last Name,Dogs,Cats,Birds,Fish\n",
+      'simple_with_header.csv' => "user_id\n",
+      'emoji.csv' => "First Name|Last Name|Purchases|Score\n",
+      'quoted.csv' => "Year,Make,Model,Description,Price\n"
+    }
+  }
+
+  let(:correct_csv_line_counts) {
+    {
+      'basic.csv' => 8,
+      'simple_with_header.csv' => 5,
+      'emoji.csv' => 4,
+      'quoted.csv' => 5
+    }
+  }
+
   it 'at least returns the right number of results from each thread' do
     data = correct_sizes.keys.map do |name|
       Thread.new { [name, SmarterCSV.process("#{fixture_path}/#{name}")] }
@@ -20,6 +56,94 @@ describe 'thread safety checks' do
     expect(data.size).to eq(4)
     data.each { |d|
       expect(d[1].size).to eq(correct_sizes[d[0]])
+    }
+  end
+
+  it 'returns the right headers for each thread' do
+    50.times do
+      data = correct_headers.keys.map do |name|
+        Thread.new {
+          rows = []
+          SmarterCSV.process("#{fixture_path}/#{name}", remove_empty_values: false) { |csv| rows += csv }
+          [
+            name, rows
+          ]
+        }
+      end.map(&:value)
+
+      expect(data.size).to eq(4)
+      data.each { |d|
+        expect(d[1].first.keys).to eq(correct_headers[d[0]])
+      }
+    end
+  end
+
+  it 'returns the right headers for each thread' do
+    50.times do
+      data = correct_headers.keys.map do |name|
+        Thread.new {
+          rows = []
+          SmarterCSV.process("#{fixture_path}/#{name}", remove_empty_values: false) { |csv| rows += csv }
+          processed_header = SmarterCSV.headers
+          [
+            name, processed_header
+          ]
+        }
+      end.map(&:value)
+
+      expect(data.size).to eq(4)
+      data.each { |d|
+        expect(d[1]).to eq(correct_headers[d[0]])
+      }
+    end
+  end
+
+  it 'returns the right raw_headers for each thread' do
+    50.times do
+      data = correct_raw_headers.keys.map do |name|
+        Thread.new {
+          rows = []
+          SmarterCSV.process("#{fixture_path}/#{name}", remove_empty_values: false) { |csv| rows += csv }
+          raw_header = SmarterCSV.raw_header
+          [
+            name, raw_header
+          ]
+        }
+      end.map(&:value)
+
+      expect(data.size).to eq(4)
+      data.each { |d|
+        expect(d[1]).to eq(correct_raw_headers[d[0]])
+      }
+    end
+  end
+
+  it 'hands back the right chunk_count for each thread' do
+    data = correct_chunk_counts.keys.map do |name|
+      Thread.new { [name, SmarterCSV.process("#{fixture_path}/#{name}", chunk_size: 2) { |c| c }] }
+    end.map(&:value)
+
+    expect(data.size).to eq(4)
+    data.each { |d|
+      expect(d[1]).to eq(correct_chunk_counts[d[0]])
+    }
+  end
+
+  it 'hands back the right csv_line_count for each thread' do
+    data = correct_raw_headers.keys.map do |name|
+      Thread.new {
+        rows = []
+        SmarterCSV.process("#{fixture_path}/#{name}", remove_empty_values: false) { |csv| rows += csv }
+        csv_line_count = SmarterCSV.csv_line_count
+        [
+          name, csv_line_count
+        ]
+      }
+    end.map(&:value)
+
+    expect(data.size).to eq(4)
+    data.each { |d|
+      expect(d[1]).to eq(correct_csv_line_counts[d[0]])
     }
   end
 end

--- a/spec/features/threading_spec.rb
+++ b/spec/features/threading_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+fixture_path = 'spec/fixtures'
+
+describe 'thread safety checks' do
+  let(:correct_sizes) {
+    {
+      'basic.csv' => 5,
+      'simple_with_header.csv' => 4,
+      'emoji.csv' => 3,
+      'quoted.csv' => 4
+    }
+  }
+
+  it 'at least returns the right number of results from each thread' do
+    data = correct_sizes.keys.map do |name|
+      Thread.new { [name, SmarterCSV.process("#{fixture_path}/#{name}")] }
+    end.map(&:value)
+
+    expect(data.size).to eq(4)
+    data.each { |d|
+      expect(d[1].size).to eq(correct_sizes[d[0]])
+    }
+  end
+end

--- a/spec/smarter_csv/parse/column_separator_spec.rb
+++ b/spec/smarter_csv/parse/column_separator_spec.rb
@@ -14,13 +14,15 @@
 
 [true, false].each do |bool|
   describe "fulfills RFC-4180 and more with#{bool ? ' C-' : 'out '}acceleration" do
+    let(:instance) { SmarterCSV.initialize_variables }
+
     describe 'parse with col_sep' do
       let(:options) { {quote_char: '"', acceleration: bool} }
 
       it 'parses with comma' do
         line = "a,b,,d"
         options.merge!({col_sep: ","})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ['a', 'b', '', 'd']
         expect(array_size).to eq 4
       end
@@ -28,7 +30,7 @@
       it 'parses trailing commas' do
         line = "a,b,c,,"
         options.merge!({col_sep: ","})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ['a', 'b', 'c', '', '']
         expect(array_size).to eq 5
       end
@@ -36,7 +38,7 @@
       it 'parses with space' do
         line = "a b  d"
         options.merge!({col_sep: " "})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ['a', 'b', '', 'd']
         expect(array_size).to eq 4
       end
@@ -44,7 +46,7 @@
       it 'parses with tab' do
         line = "a\tb\t\td"
         options.merge!({col_sep: "\t"})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ['a', 'b', '', 'd']
         expect(array_size).to eq 4
       end
@@ -52,7 +54,7 @@
       it 'parses with multiple space separator' do
         line = "a b    d"
         options.merge!({col_sep: "  "})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ['a b', '', 'd']
         expect(array_size).to eq 3
       end
@@ -60,7 +62,7 @@
       it 'parses with multiple char separator' do
         line = '<=><=>A<=>B<=>C'
         options.merge!({col_sep: "<=>"})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ["", "", "A", "B", "C"]
         expect(array_size).to eq 5
       end
@@ -68,7 +70,7 @@
       it 'parses trailing multiple char separator' do
         line = '<=><=>A<=>B<=>C<=><=>'
         options.merge!({col_sep: "<=>"})
-        array, array_size = SmarterCSV.send(:parse, line, options)
+        array, array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ["", "", "A", "B", "C", "", ""]
         expect(array_size).to eq 7
       end

--- a/spec/smarter_csv/parse/max_size_spec.rb
+++ b/spec/smarter_csv/parse/max_size_spec.rb
@@ -18,6 +18,7 @@
 
 [true, false].each do |bool|
   describe "fulfills RFC-4180 and more with#{bool ? ' C-' : 'out '}acceleration" do
+    let(:instance) { SmarterCSV.initialize_variables }
     let(:options) { {acceleration: bool} }
 
     describe 'splitting line up to max_size' do
@@ -28,61 +29,61 @@
       context 'without quotes' do
         it 'without max_size' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options)
           expect(array).to eq %w[1 2 3 4 5 6]
         end
 
         it 'with max_size = 7' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 7)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 7)
           expect(array).to eq %w[1 2 3 4 5 6]
         end
 
         it 'with max_size = 6' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 6)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 6)
           expect(array).to eq %w[1 2 3 4 5 6]
         end
 
         it 'with max_size = 5' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 5)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 5)
           expect(array).to eq %w[1 2 3 4 5]
         end
 
         it 'with max_size = 4' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 4)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 4)
           expect(array).to eq %w[1 2 3 4]
         end
 
         it 'with max_size = 3' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 3)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 3)
           expect(array).to eq %w[1 2 3]
         end
 
         it 'with max_size = 2' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 2)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 2)
           expect(array).to eq %w[1 2]
         end
 
         it 'with max_size = 1' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 1)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 1)
           expect(array).to eq ['1']
         end
 
         it 'with max_size = 0' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 0)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 0)
           expect(array).to eq []
         end
 
         it 'with max_size = -1' do
           line = '1,2,3,4,5,6'
-          array, _array_size = SmarterCSV.send(:parse, line, options, -1)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, -1)
           expect(array).to eq []
         end
       end
@@ -90,61 +91,61 @@
       context 'with quotes' do
         it 'without max_size' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options)
           expect(array).to eq %w[1 2 3 4 5 6]
         end
 
         it 'with max_size = 7' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 7)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 7)
           expect(array).to eq %w[1 2 3 4 5 6]
         end
 
         it 'with max_size = 6' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 6)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 6)
           expect(array).to eq %w[1 2 3 4 5 6]
         end
 
         it 'with max_size = 5' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 5)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 5)
           expect(array).to eq %w[1 2 3 4 5]
         end
 
         it 'with max_size = 4' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 4)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 4)
           expect(array).to eq %w[1 2 3 4]
         end
 
         it 'with max_size = 3' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 3)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 3)
           expect(array).to eq %w[1 2 3]
         end
 
         it 'with max_size = 2' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 2)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 2)
           expect(array).to eq %w[1 2]
         end
 
         it 'with max_size = 1' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 1)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 1)
           expect(array).to eq ['1']
         end
 
         it 'with max_size = 0' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, 0)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, 0)
           expect(array).to eq []
         end
 
         it 'with max_size = -1' do
           line = '"1","2","3","4","5","6"'
-          array, _array_size = SmarterCSV.send(:parse, line, options, -1)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options, -1)
           expect(array).to eq []
         end
       end

--- a/spec/smarter_csv/parse/old_csv_library_spec.rb
+++ b/spec/smarter_csv/parse/old_csv_library_spec.rb
@@ -14,6 +14,8 @@
 
 [true, false].each do |bool|
   describe "fulfills RFC-4180 and more with#{bool ? ' C-' : 'out '}acceleration" do
+    let(:instance) { SmarterCSV.initialize_variables }
+
     describe 'old CSV library parsing tests' do
       let(:options) { {quote_char: '"', col_sep: ",", acceleration: bool} }
 
@@ -45,7 +47,7 @@
        ["foo,\"foo,bar\",baz", ["foo", "foo,bar", "baz"]],
        [";,;", [";", ";"]]].each do |line, result|
         it "parses #{line} as #{result.inspect}" do
-          array, _array_size = SmarterCSV.send(:parse, line, options)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options)
           expect(array).to eq result
         end
       end
@@ -67,26 +69,26 @@
        ["foo,\"\r\n\n\",baz", ["foo", "\r\n\n", "baz"]],
        ["foo,\"foo,bar\",baz", ["foo", "foo,bar", "baz"]]].each do |line, result|
         it "parses #{line} as #{result.inspect}" do
-          array, _array_size = SmarterCSV.send(:parse, line, options)
+          array, _array_size = SmarterCSV.send(:parse, instance, line, options)
           expect(array).to eq result
         end
       end
 
       it 'quoted test' do
         line = '"This",is,2"","3""",test'
-        array, _array_size = SmarterCSV.send(:parse, line, options)
+        array, _array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ["This", "is", '2"', '3"', "test"]
       end
 
       it 'mixed quotes' do
         line = %{Ten Thousand,10000, 2710 ,,"10,000","It's ""10 Grand"", baby",10K}
-        array, _array_size = SmarterCSV.send(:parse, line, options)
+        array, _array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ["Ten Thousand", "10000", " 2710 ", "", "10,000", "It's \"10 Grand\", baby", "10K"]
       end
 
       it 'single quotes in fields' do
         line = 'Indoor Chrome,49.2"" L x 49.2"" W x 20.5"" H,Chrome,"Crystal,Metal,Wood",23.12'
-        array, _array_size = SmarterCSV.send(:parse, line, options)
+        array, _array_size = SmarterCSV.send(:parse, instance, line, options)
         expect(array).to eq ['Indoor Chrome', '49.2" L x 49.2" W x 20.5" H', 'Chrome', 'Crystal,Metal,Wood', '23.12']
       end
     end

--- a/spec/smarter_csv/parse/rfc4180_and_more_spec.rb
+++ b/spec/smarter_csv/parse/rfc4180_and_more_spec.rb
@@ -15,17 +15,18 @@
 [true, false].each do |bool|
   describe "fulfills RFC-4180 and more with#{bool ? ' C-' : 'out '}acceleration" do
     let(:options) { {col_sep: ',', row_sep: $INPUT_RECORD_SEPARATOR, quote_char: '"', acceleration: bool } }
+    let(:instance) { SmarterCSV.initialize_variables }
 
     context 'parses simple CSV' do
       context 'RFC-4180' do
         it 'separating on col_sep' do
           line = 'aaa,bbb,ccc'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [%w[aaa bbb ccc], 3]
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [%w[aaa bbb ccc], 3]
         end
 
         it 'preserves whitespace' do
           line = ' aaa , bbb , ccc '
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             [' aaa ', ' bbb ', ' ccc '], 3
           ]
         end
@@ -34,42 +35,42 @@
       context 'extending RFC-4180' do
         it 'with extra col_sep' do
           line = 'aaa,bbb,ccc,'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['aaa', 'bbb', 'ccc', ''], 4
           ]
         end
 
         it 'with extra col_sep with given header_size' do
           line = 'aaa,bbb,ccc,'
-          expect(SmarterCSV.send(:parse, line, options, 3)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options, 3)).to eq [
             %w[aaa bbb ccc], 3
           ]
         end
 
         it 'with multiple extra col_sep' do
           line = 'aaa,bbb,ccc,,,'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['aaa', 'bbb', 'ccc', '', '', ''], 6
           ]
         end
 
         it 'with multiple extra col_sep' do
           line = 'aaa,bbb,ccc,,,'
-          expect(SmarterCSV.send(:parse, line, options, 3)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options, 3)).to eq [
             %w[aaa bbb ccc], 3
           ]
         end
 
         it 'with multiple complex col_sep' do
           line = 'aaa<=>bbb<=>ccc<=><=><=>'
-          expect(SmarterCSV.send(:parse, line, options.merge({col_sep: '<=>'}))).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options.merge({col_sep: '<=>'}))).to eq [
             ['aaa', 'bbb', 'ccc', '', '', ''], 6
           ]
         end
 
         it 'with multiple complex col_sep with given header_size' do
           line = 'aaa<=>bbb<=>ccc<=><=><=>'
-          expect(SmarterCSV.send(:parse, line, options.merge({col_sep: '<=>'}), 3)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options.merge({col_sep: '<=>'}), 3)).to eq [
             %w[aaa bbb ccc], 3
           ]
         end
@@ -80,47 +81,47 @@
       context 'RFC-4180' do
         it 'separating on col_sep' do
           line = '"aaa","bbb","ccc"'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [%w[aaa bbb ccc], 3]
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [%w[aaa bbb ccc], 3]
         end
 
         it 'parses corner case correctly' do
           line = '"Board 4""","$17.40","10000003427"'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['Board 4"', '$17.40', '10000003427'], 3
           ]
         end
 
         it 'quoted parts can contain spaces' do
           line = '" aaa1 aaa2 "," bbb1 bbb2 "," ccc1 ccc2 "'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             [' aaa1 aaa2 ', ' bbb1 bbb2 ', ' ccc1 ccc2 '], 3
           ]
         end
 
         it 'quoted parts can contain row_sep' do
           line = '"aaa1, aaa2","bbb1, bbb2","ccc1, ccc2"'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['aaa1, aaa2', 'bbb1, bbb2', 'ccc1, ccc2'], 3
           ]
         end
 
         it 'quoted parts can contain row_sep' do
           line = '"aaa1, ""aaa2"", aaa3","""bbb1"", bbb2","ccc1, ""ccc2"""'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['aaa1, "aaa2", aaa3', '"bbb1", bbb2', 'ccc1, "ccc2"'], 3
           ]
         end
 
         it 'some fields are quoted' do
           line = '1,"board 4""",12.95'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['1', 'board 4"', '12.95'], 3
           ]
         end
 
         it 'separating on col_sep' do
           line = '"some","thing","""completely"" different"'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['some', 'thing', '"completely" different'], 3
           ]
         end
@@ -129,40 +130,40 @@
       context 'extending RFC-4180' do
         it 'with extra col_sep, without given header_size' do
           line = '"aaa","bbb","ccc",'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['aaa', 'bbb', 'ccc', ''], 4
           ]
         end
 
         it 'with extra col_sep, with given header_size' do
           line = '"aaa","bbb","ccc",'
-          expect(SmarterCSV.send(:parse, line, options, 3)).to eq [%w[aaa bbb ccc], 3]
+          expect(SmarterCSV.send(:parse, instance, line, options, 3)).to eq [%w[aaa bbb ccc], 3]
         end
 
         it 'with multiple extra col_sep, without given header_size' do
           line = '"aaa","bbb","ccc",,,'
-          expect(SmarterCSV.send(:parse, line, options)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
             ['aaa', 'bbb', 'ccc', '', '', ''], 6
           ]
         end
 
         it 'with multiple extra col_sep, with given header_size' do
           line = '"aaa","bbb","ccc",,,'
-          expect(SmarterCSV.send(:parse, line, options, 3)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options, 3)).to eq [
             %w[aaa bbb ccc], 3
           ]
         end
 
         it 'with multiple complex extra col_sep, without given header_size' do
           line = '"aaa"<=>"bbb"<=>"ccc"<=><=><=>'
-          expect(SmarterCSV.send(:parse, line, options.merge({col_sep: '<=>'}))).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options.merge({col_sep: '<=>'}))).to eq [
             ['aaa', 'bbb', 'ccc', '', '', ''], 6
           ]
         end
 
         it 'with multiple complex extra col_sep, with given header_size' do
           line = '"aaa"<=>"bbb"<=>"ccc"<=><=><=>'
-          expect(SmarterCSV.send(:parse, line, options.merge({col_sep: '<=>'}), 3)).to eq [
+          expect(SmarterCSV.send(:parse, instance, line, options.merge({col_sep: '<=>'}), 3)).to eq [
             %w[aaa bbb ccc], 3
           ]
         end
@@ -173,7 +174,7 @@
     context 'liberal_parsing' do
       it 'parses corner case correctly' do
         line = 'is,this "three, or four",fields'
-        expect(SmarterCSV.send(:parse, line, options)).to eq [
+        expect(SmarterCSV.send(:parse, instance, line, options)).to eq [
           ['is', 'this "three, or four"', 'fields'], 3
         ]
       end


### PR DESCRIPTION
* SmarterCSV used instance variables on a module, so they were shared across all threads

* When different threads ran SmarterCSV, they could overwrite the instance values that were set, and effectively corrupt eachothers data. The simplest way to show this was to run a full `process` call from multiple threads - each threads data gets aggregated together into one large result

* By using an instance, and passing it around, we simulate an instance approach while maintaining the current API

* We also expose a thread-local set of instance variables which should provide backwards compatibility if someone were to directly access the global instance variables on the SmarterCSV module (which a spec did, and that's how I noticed this behavior)