### PR TITLE
Correct typo in data_transformations.md

### DIFF
--- a/docs/data_transformations.md
+++ b/docs/data_transformations.md
@@ -51,7 +51,7 @@ It can happen that after all transformations, a row of the CSV file would produc
 
 By default SmarterCSV uses `remove_empty_hashes: true` to remove these empty hashes from the result.
 
-This can be set to `true`, to keep these empty hashes in the results.
+This can be set to `false`, to keep these empty hashes in the results.
 
 -------------------
 PREVIOUS: [Header Validations](./header_validations.md) | NEXT: [Value Converters](./value_converters.md)


### PR DESCRIPTION
The docs had swapped true for false in the `remove_empty_hashes` section. 