### PR TITLE
removing mentions of obsolete option force_simple_split

### DIFF
--- a/docs/header_transformations.md
+++ b/docs/header_transformations.md
@@ -108,8 +108,7 @@ For CSV files with headers, you can either:
  * if the incorrect number of headers are provided via :user_provided_headers, versions >1.13 will automatically add column names `column_N` for additional unexpected columns. If you want to raise an error instead, add option `strict: true`, and it will raise `SmarterCSV::HeaderSizeMismatch`.
 
 ### NOTES on improper quotation and unwanted characters in headers:
- * some CSV files use un-escaped quotation characters inside fields. This can cause the import to break. To get around this, use the `:force_simple_split => true` option in combination with `:strip_chars_from_headers => /[\-"]/` . This will also significantly speed up the import.
-   If you would force a different :quote_char instead (setting it to a non-used character), then the import would be up to 5-times slower than using `:force_simple_split`.
+ * some CSV files use un-escaped quotation characters inside fields. This can cause the import to break. To get around this, set the `quote_char` to something different, e.g. `quote_char: "%"`, or try setting `:strip_chars_from_headers => /[\-"]/` 
 
 ---------------
 PREVIOUS: [Row and Column Separators](./row_col_sep.md) | NEXT: [Header Validations](./header_validations.md) 

--- a/docs/options.md
+++ b/docs/options.md
@@ -41,9 +41,7 @@
      | :skip_lines                 |   nil    | how many lines to skip before the first line or header line is processed             |
      | :comment_regexp             |   nil    | regular expression to ignore comment lines (see NOTE on CSV header), e.g./\A#/       |
      ---------------------------------------------------------------------------------------------------------------------------------
-     | :col_sep                    |   :auto   | column separator (default was ',')                                                  |
-     | :force_simple_split         |   false  | force simple splitting on :col_sep character for non-standard CSV-files.             |
-     |                             |          | e.g. when :quote_char is not properly escaped                                        |
+     | :col_sep                    |  :auto   | column separator (default was ',')                                                   |
      | :row_sep                    |  :auto   | row separator or record separator (previous default was system's $/ , which defaulted to "\n") |
      |                             |          | This can also be set to :auto, but will process the whole cvs file first  (slow!)    |
      | :auto_row_sep_chars         |   500    | How many characters to analyze when using `:row_sep => :auto`. nil or 0 means whole file. |

--- a/lib/smarter_csv/options.rb
+++ b/lib/smarter_csv/options.rb
@@ -20,7 +20,6 @@ module SmarterCSV
       downcase_header: true,
       duplicate_header_suffix: '', # was: nil,
       file_encoding: 'utf-8',
-      force_simple_split: false,
       force_utf8: false,
       headers_in_file: true,
       invalid_byte_sequence: '',


### PR DESCRIPTION
this options was deleted a while ago, but docs and default options still mentioned them.