### PR TITLE
Work on Version 1.16.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ coverage/*
 .rspec_status
 .DS_Store
 vendor/bundle
+*.md
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage/*
 vendor/bundle
 *.md
 .claude/
+benchmark/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,6 +121,9 @@ Style/PercentLiteralDelimiters:
 Style/RegexpLiteral:
   Enabled: false
 
+Style/RescueModifier:
+  Enabled: false
+
 Style/SafeNavigation:
   Enabled: false
 
@@ -151,6 +154,9 @@ Style/SymbolArray:
   Enabled: false
 
 Style/SymbolProc: # old Ruby versions can't do this
+  Enabled: false
+
+Style/TernaryParentheses:
   Enabled: false
 
 Style/TrailingCommaInArrayLiteral:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 
 # SmarterCSV 1.x Change Log
 
-## 1.16.4 (2026-04-18) — Bug Fix
+## 1.16.4 (2026-04-21) — Bug Fixes
 
-RSpec tests: **1,434 → 1,446** (+12 tests)
+RSpec tests: **1,434 → 1,467** (+33 tests)
 
 ### Bug Fixes
 
 * Fixed bug in `SmarterCSV.errors` that could lose collected records when processing raises mid-stream,
   e.g. when `bad_row_limit:` was exceeded (`TooManyBadRows`), or when a user's block raised through `.process` / `.each` / `.each_chunk`.
+
+* Fixed `enforce_utf8_encoding` incorrectly replacing all non-ASCII bytes when the input string was tagged as `ASCII-8BIT` (binary).
+  The encoding is now relabeled to UTF-8 before transcoding, so only genuinely invalid byte sequences are replaced.
 
 ## 1.16.3 (2026-04-14) — New Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 
 # SmarterCSV 1.x Change Log
 
+## 1.16.4 (2026-04-18) — Bug Fix
+
+RSpec tests: **1,434 → 1,446** (+12 tests)
+
+### Bug Fixes
+
+* Fixed bug in `SmarterCSV.errors` that could lose collected records when processing raises mid-stream,
+  e.g. when `bad_row_limit:` was exceeded (`TooManyBadRows`), or when a user's block raised through `.process` / `.each` / `.each_chunk`.
+
 ## 1.16.3 (2026-04-14) — New Feature
 
 RSpec tests: **1,425 → 1,434** (+9 tests)

--- a/lib/smarter_csv.rb
+++ b/lib/smarter_csv.rb
@@ -78,9 +78,12 @@ module SmarterCSV
   def self.process(input, given_options = {}, &block)
     Thread.current[:current_thread_recent_errors] = {}
     reader = Reader.new(input, given_options)
-    result = reader.process(&block)
-    Thread.current[:current_thread_recent_errors] = reader.errors
-    result
+    reader.process(&block)
+  ensure
+    # Preserve partial error state when processing raises mid-stream
+    # (e.g. TooManyBadRows, or a user block raising). `reader` is nil if
+    # Reader.new itself raised before the local was assigned.
+    Thread.current[:current_thread_recent_errors] = reader.errors if reader
   end
 
   # Convenience method for parsing a CSV string directly.
@@ -109,9 +112,9 @@ module SmarterCSV
   def self.each(input, options = {}, &block)
     Thread.current[:current_thread_recent_errors] = {}
     reader = Reader.new(input, options)
-    result = reader.each(&block)
-    Thread.current[:current_thread_recent_errors] = reader.errors
-    result
+    reader.each(&block)
+  ensure
+    Thread.current[:current_thread_recent_errors] = reader.errors if reader
   end
 
   # Yields each chunk as Array<Hash> plus its 0-based chunk index.
@@ -126,9 +129,9 @@ module SmarterCSV
   def self.each_chunk(input, options = {}, &block)
     Thread.current[:current_thread_recent_errors] = {}
     reader = Reader.new(input, options)
-    result = reader.each_chunk(&block)
-    Thread.current[:current_thread_recent_errors] = reader.errors
-    result
+    reader.each_chunk(&block)
+  ensure
+    Thread.current[:current_thread_recent_errors] = reader.errors if reader
   end
 
   # Returns the errors from the most recent call to .process, .parse, .each, or .each_chunk
@@ -198,7 +201,7 @@ module SmarterCSV
       begin
         yield writer
       ensure
-        writer&.finalize  # must finalize before reading io.string
+        writer&.finalize # must finalize before reading io.string
       end
       io.string
     else

--- a/lib/smarter_csv/reader.rb
+++ b/lib/smarter_csv/reader.rb
@@ -147,9 +147,9 @@ module SmarterCSV
           options[:_keep_bitmap]       = keep_flags.map { |f| f ? 1 : 0 }.pack('C*').freeze
           options[:_keep_extra_cols]   = @only_headers_set ? false : true
           options[:_early_exit_after]  = (@only_headers_set && !options[:strict]) ? (keep_flags.rindex(true) || -1) : -1
-          options[:_keep_cols]         = nil   # nil signals C: "filter active, check _keep_bitmap"
+          options[:_keep_cols]         = nil # nil signals C: "filter active, check _keep_bitmap"
         else
-          options[:_keep_cols] = false  # sentinel: no filtering active — C skips all bitmap paths
+          options[:_keep_cols] = false # sentinel: no filtering active — C skips all bitmap paths
           # Do NOT insert _keep_bitmap/_keep_extra_cols/_early_exit_after when unused.
           # Keeping the options hash as small as possible avoids hash table resize and
           # keeps all 10 per-row rb_hash_aref lookups hitting the same cache lines.
@@ -214,18 +214,18 @@ module SmarterCSV
         # on_start / on_chunk / on_complete are optional callables (nil by default).
         # Hooks only fire from `process` (library-controlled iteration). Enumerator
         # modes (each / each_chunk) do not fire hooks — the caller owns the lifecycle.
-        _on_start    = options[:on_start]
-        _on_chunk    = options[:on_chunk]
-        _on_complete = options[:on_complete]
-        _start_time  = Process.clock_gettime(Process::CLOCK_MONOTONIC) if _on_start || _on_complete
+        on_start    = options[:on_start]
+        on_chunk    = options[:on_chunk]
+        on_complete = options[:on_complete]
+        start_time  = Process.clock_gettime(Process::CLOCK_MONOTONIC) if on_start || on_complete
 
-        if _on_start
-          _input_meta = if @input.is_a?(String)
+        if on_start
+          input_meta = if @input.is_a?(String)
                           { input: @input, file_size: (File.size(@input) rescue nil) }
                         else
                           { input: @input.class.name, file_size: nil }
-                        end
-          _on_start.call(_input_meta.merge(col_sep: options[:col_sep], row_sep: options[:row_sep]))
+                       end
+          on_start.call(input_meta.merge(col_sep: options[:col_sep], row_sep: options[:row_sep]))
         end
 
         # now on to processing all the rest of the lines in the CSV file:
@@ -385,7 +385,7 @@ module SmarterCSV
             chunk << hash # append temp result to chunk
 
             if chunk.size >= chunk_size || fh.eof? # if chunk if full, or EOF reached
-              _on_chunk&.call({ chunk_number: @chunk_count + 1, rows_in_chunk: chunk.size, total_rows_so_far: @csv_line_count })
+              on_chunk&.call({ chunk_number: @chunk_count + 1, rows_in_chunk: chunk.size, total_rows_so_far: @csv_line_count })
               # do something with the chunk
               if block_given?
                 yield chunk, @chunk_count # do something with the hashes in the chunk in the block
@@ -414,7 +414,7 @@ module SmarterCSV
 
         # handling of last chunk:
         if !chunk.nil? && chunk.size > 0
-          _on_chunk&.call({ chunk_number: @chunk_count + 1, rows_in_chunk: chunk.size, total_rows_so_far: @csv_line_count })
+          on_chunk&.call({ chunk_number: @chunk_count + 1, rows_in_chunk: chunk.size, total_rows_so_far: @csv_line_count })
           # do something with the chunk
           if block_given?
             yield chunk, @chunk_count # do something with the hashes in the chunk in the block
@@ -425,13 +425,13 @@ module SmarterCSV
           # chunk = [] # initialize for next chunk of data
         end
 
-        if _on_complete
-          _on_complete.call({
-            total_rows:   @csv_line_count,
-            total_chunks: @chunk_count,
-            duration:     Process.clock_gettime(Process::CLOCK_MONOTONIC) - _start_time,
-            bad_rows:     @errors[:bad_row_count] || 0,
-          })
+        if on_complete
+          on_complete.call({
+                             total_rows: @csv_line_count,
+                             total_chunks: @chunk_count,
+                             duration: Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time,
+                             bad_rows: @errors[:bad_row_count] || 0,
+                           })
         end
       ensure
         fh.close if fh.respond_to?(:close)
@@ -662,12 +662,10 @@ module SmarterCSV
             # else: mid-field quote → literal, no state change
           elsif !in_quotes
             # Non-quote character: track whether field has started
-            if strip
-              # rubocop:disable Style/MultipleComparison -- two direct == comparisons are faster than Array#include? in this hot loop
+            if strip # -- two direct == comparisons are faster than Array#include? in this hot loop
               field_started = true unless line[i] == ' ' || line[i] == "\t"
-              # rubocop:enable Style/MultipleComparison
-            else
-              field_started = true
+                          else
+                            field_started = true
             end
           end
           i += 1
@@ -780,9 +778,13 @@ module SmarterCSV
     end
 
     def enforce_utf8_encoding(line, options)
-      # return line unless options[:force_utf8] || options[:file_encoding] !~ /utf-8/i
-
-      line.force_encoding('utf-8').encode('utf-8', invalid: :replace, undef: :replace, replace: options[:invalid_byte_sequence])
+      replace = options[:invalid_byte_sequence]
+      # ASCII_8BIT (Encoding::BINARY is an alias) has no codepoint mapping above 0x7F,
+      # so encode('utf-8', ASCII_8BIT) would replace every non-ASCII byte. Relabel as
+      # UTF-8 first so encode() treats the bytes as already-UTF-8 and only replaces
+      # sequences that are actually invalid.
+      line = line.force_encoding('utf-8') if line.encoding == Encoding::ASCII_8BIT
+      line.encode('utf-8', line.encoding, invalid: :replace, undef: :replace, replace: replace)
     end
 
     def handle_bad_row(error, line, start_csv_line, start_file_line, options)

--- a/lib/smarter_csv/version.rb
+++ b/lib/smarter_csv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SmarterCSV
-  VERSION = "1.16.3"
+  VERSION = "1.16.4"
 end

--- a/spec/smarter_csv/errors_preservation_spec.rb
+++ b/spec/smarter_csv/errors_preservation_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Regression tests for: SmarterCSV.errors loses collected records when
+# processing raises mid-stream.
+#
+# Before the fix, the class-level `SmarterCSV.errors` was only populated on
+# the happy path — if processing raised (e.g. TooManyBadRows), the thread-local
+# state stayed at `{}` from the start-of-call reset, discarding every bad row
+# the reader had already collected. This defeated the on_bad_row: :collect +
+# bad_row_limit: feature at the exact threshold where it should have helped.
+#
+# See loosing_errors_bug.md for the full write-up.
+
+describe 'SmarterCSV.errors — preservation across exceptions' do
+  # Headers = 2 cols. Data rows with an extra col are "bad" only when
+  # missing_headers: :raise (default :auto auto-names extra cols instead).
+  let(:base_options) { { missing_headers: :raise } }
+  let(:dirty_csv_string) do
+    header = "a,b\n"
+    bad_rows = Array.new(150) { "x,y,EXTRA\n" }.join
+    header + bad_rows
+  end
+
+  context 'when bad_row_limit is exceeded (TooManyBadRows raised)' do
+    it 'preserves collected bad_rows up to the limit' do
+      expect {
+        SmarterCSV.parse(dirty_csv_string, base_options.merge(on_bad_row: :collect, bad_row_limit: 50))
+      }.to raise_error(SmarterCSV::TooManyBadRows)
+
+      expect(SmarterCSV.errors[:bad_rows]).to be_an(Array)
+      expect(SmarterCSV.errors[:bad_rows].size).to be >= 50
+      expect(SmarterCSV.errors[:bad_row_count]).to be >= 51
+    end
+
+    it 'preserves bad_row_count when on_bad_row: :skip + bad_row_limit' do
+      expect {
+        SmarterCSV.parse(dirty_csv_string, base_options.merge(on_bad_row: :skip, bad_row_limit: 20))
+      }.to raise_error(SmarterCSV::TooManyBadRows)
+
+      expect(SmarterCSV.errors[:bad_row_count]).to be >= 21
+    end
+  end
+
+  context 'when the user block raises mid-processing' do
+    it 'preserves errors accumulated before the block raised' do
+      # Bad row comes first (row 2), then a good row that triggers the block raise.
+      dirty = "a,b\nbad,row,extra\nok1,ok2\n"
+
+      expect {
+        SmarterCSV.parse(dirty, base_options.merge(on_bad_row: :collect)) { |_row| raise 'boom' }
+      }.to raise_error(/boom/)
+
+      # Without the fix this would be {} because the `reader.errors` copy
+      # happens after reader.process returns, which it never does when the
+      # user's block raises.
+      expect(SmarterCSV.errors).not_to eq({})
+      expect(SmarterCSV.errors[:bad_row_count]).to eq(1)
+    end
+  end
+
+  context 'when Reader.new raises (e.g. bad input path)' do
+    it 'leaves SmarterCSV.errors as an empty hash (nothing to preserve)' do
+      expect {
+        SmarterCSV.process('/tmp/definitely_does_not_exist_xyz.csv')
+      }.to raise_error(StandardError)
+
+      expect(SmarterCSV.errors).to eq({})
+    end
+  end
+
+  context '.each' do
+    # Fixture layout: good, bad, bad, good
+    let(:fixture) { 'spec/fixtures/bad_row_quarantine_multi.csv' }
+
+    it 'preserves collected bad_rows when bad_row_limit is exceeded (:collect)' do
+      expect {
+        SmarterCSV.each(fixture, base_options.merge(on_bad_row: :collect, bad_row_limit: 1)) { |_row| }
+      }.to raise_error(SmarterCSV::TooManyBadRows)
+
+      expect(SmarterCSV.errors[:bad_rows]).to be_an(Array)
+      expect(SmarterCSV.errors[:bad_rows].size).to be >= 1
+    end
+
+    it 'preserves bad_row_count when bad_row_limit is exceeded (:skip)' do
+      expect {
+        SmarterCSV.each(fixture, base_options.merge(on_bad_row: :skip, bad_row_limit: 1)) { |_row| }
+      }.to raise_error(SmarterCSV::TooManyBadRows)
+
+      expect(SmarterCSV.errors[:bad_row_count]).to be >= 2
+    end
+
+    it 'preserves errors when the user block raises' do
+      # Raise on the 2nd yield so the two bad rows between the first and
+      # second good rows have already been collected before the block blows up.
+      count = 0
+      expect {
+        SmarterCSV.each(fixture, base_options.merge(on_bad_row: :collect)) do |_row|
+          count += 1
+          raise 'boom' if count >= 2
+        end
+      }.to raise_error(/boom/)
+
+      expect(SmarterCSV.errors[:bad_row_count]).to eq(2)
+      expect(SmarterCSV.errors[:bad_rows].size).to eq(2)
+    end
+
+    it 'leaves SmarterCSV.errors as {} when Reader.new raises' do
+      expect {
+        SmarterCSV.each('/tmp/definitely_does_not_exist_xyz.csv') { |_row| }
+      }.to raise_error(StandardError)
+
+      expect(SmarterCSV.errors).to eq({})
+    end
+  end
+
+  context '.each_chunk' do
+    let(:fixture) { 'spec/fixtures/bad_row_quarantine_multi.csv' }
+
+    it 'preserves collected bad_rows when bad_row_limit is exceeded (:collect)' do
+      expect {
+        SmarterCSV.each_chunk(fixture, base_options.merge(on_bad_row: :collect, bad_row_limit: 1, chunk_size: 1)) { |_chunk| }
+      }.to raise_error(SmarterCSV::TooManyBadRows)
+
+      expect(SmarterCSV.errors[:bad_rows]).to be_an(Array)
+      expect(SmarterCSV.errors[:bad_rows].size).to be >= 1
+    end
+
+    it 'preserves bad_row_count when bad_row_limit is exceeded (:skip)' do
+      expect {
+        SmarterCSV.each_chunk(fixture, base_options.merge(on_bad_row: :skip, bad_row_limit: 1, chunk_size: 1)) { |_chunk| }
+      }.to raise_error(SmarterCSV::TooManyBadRows)
+
+      expect(SmarterCSV.errors[:bad_row_count]).to be >= 2
+    end
+
+    it 'preserves errors when the user block raises' do
+      # chunk_size: 1 → chunk 1 = [John], then Jane+Mike are bad rows,
+      # then chunk 2 = [Bob] → raise. By that point 2 bad rows are collected.
+      count = 0
+      expect {
+        SmarterCSV.each_chunk(fixture, base_options.merge(on_bad_row: :collect, chunk_size: 1)) do |_chunk|
+          count += 1
+          raise 'boom' if count >= 2
+        end
+      }.to raise_error(/boom/)
+
+      expect(SmarterCSV.errors[:bad_row_count]).to eq(2)
+      expect(SmarterCSV.errors[:bad_rows].size).to eq(2)
+    end
+
+    it 'leaves SmarterCSV.errors as {} when Reader.new raises' do
+      expect {
+        SmarterCSV.each_chunk('/tmp/definitely_does_not_exist_xyz.csv', chunk_size: 10) { |_chunk| }
+      }.to raise_error(StandardError)
+
+      expect(SmarterCSV.errors).to eq({})
+    end
+  end
+end

--- a/spec/smarter_csv/file_encoding_spec.rb
+++ b/spec/smarter_csv/file_encoding_spec.rb
@@ -1,6 +1,215 @@
 # frozen_string_literal: true
 
+require 'tempfile'
+
 RSpec.describe SmarterCSV do
+  # ---------------------------------------------------------------------------
+  # enforce_utf8_encoding — unit-level tests
+  #
+  # This private method is called on every line when @enforce_utf8 = true, which
+  # happens when file_encoding !~ /utf-8/i or force_utf8: true.
+  #
+  # The key invariant: non-ASCII bytes must be TRANSCODED to UTF-8, not dropped.
+  # force_encoding('utf-8') is a lie — it relabels bytes without converting them,
+  # turning valid ISO-8859-1/Windows-1252 codepoints into invalid UTF-8 sequences
+  # that encode() then replaces with ''.  The fix is to use line.encoding as the
+  # source in encode() whenever the line carries a known non-UTF-8 encoding.
+  # ---------------------------------------------------------------------------
+  describe '#enforce_utf8_encoding (via send)' do
+    let(:reader) do
+      r = SmarterCSV::Reader.new(StringIO.new("a\n1\n"), {})
+      r.send(:process) rescue nil
+      r
+    end
+
+    def transcode(reader, str)
+      reader.send(:enforce_utf8_encoding, str, { invalid_byte_sequence: '' })
+    end
+
+    context 'ISO-8859-1 input (file_encoding: iso-8859-1)' do
+      # \xe9 = é, \xfc = ü in ISO-8859-1
+      let(:line) { "M\xFCnchen, caf\xe9".b.force_encoding('ISO-8859-1') }
+
+      it 'transcodes non-ASCII characters to UTF-8 (not drops them)' do
+        result = transcode(reader, line)
+        expect(result).to eq('München, café')
+      end
+
+      it 'returns a valid UTF-8 string' do
+        result = transcode(reader, line)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.valid_encoding?).to be true
+      end
+    end
+
+    context 'Windows-1252 input (file_encoding: windows-1252)' do
+      # \x80 = € (euro sign) in Windows-1252; not a valid ISO-8859-1 or UTF-8 byte
+      let(:line) { "price: \x80100".b.force_encoding('Windows-1252') }
+
+      it 'transcodes Windows-1252 bytes including the euro sign' do
+        result = transcode(reader, line)
+        expect(result).to eq('price: €100')
+      end
+
+      it 'returns a valid UTF-8 string' do
+        result = transcode(reader, line)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.valid_encoding?).to be true
+      end
+    end
+
+    context 'UTF-8 input with invalid bytes (force_utf8: true on a UTF-8 file)' do
+      # \xc3\xbc = ü in UTF-8 (valid); \xff is invalid in UTF-8
+      let(:valid_utf8)   { "M\xC3\xBCnchen".dup.force_encoding('UTF-8') }
+      let(:invalid_utf8) { "bad\xFF byte".dup.force_encoding('UTF-8') }
+
+      it 'leaves valid UTF-8 unchanged' do
+        result = transcode(reader, valid_utf8)
+        expect(result).to eq('München')
+        expect(result.encoding).to eq(Encoding::UTF_8)
+      end
+
+      it 'replaces invalid UTF-8 sequences with the replacement string' do
+        result = transcode(reader, invalid_utf8)
+        expect(result).to eq('bad byte')
+        expect(result.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context 'ASCII-8BIT input (file_encoding: binary — Encoding::BINARY is an alias for Encoding::ASCII_8BIT)' do
+      # .b returns a string tagged as Encoding::ASCII_8BIT.
+      # Encoding::BINARY is just another name for the same constant — same object identity.
+      let(:line) { "M\xC3\xBCnchen".b }
+
+      it 'input is tagged as ASCII_8BIT (the canonical name)' do
+        expect(line.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it 'Encoding::BINARY is the same object as Encoding::ASCII_8BIT' do
+        expect(Encoding::BINARY).to equal(Encoding::ASCII_8BIT)
+      end
+
+      it 'reinterprets ASCII_8BIT bytes as UTF-8 and returns a valid UTF-8 string' do
+        result = transcode(reader, line)
+        expect(result).to eq('München')
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.valid_encoding?).to be true
+      end
+    end
+
+    context 'Shift-JIS input (file_encoding: shift_jis)' do
+      # encode() produces a new (unfrozen) string in Shift-JIS
+      let(:line) { '東京, 大阪'.encode('Shift_JIS') }
+
+      it 'transcodes Shift-JIS characters to UTF-8' do
+        expect(transcode(reader, line)).to eq('東京, 大阪')
+      end
+
+      it 'returns a valid UTF-8 string' do
+        result = transcode(reader, line)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.valid_encoding?).to be true
+      end
+    end
+
+    context 'EUC-JP input (file_encoding: euc-jp)' do
+      let(:line) { '東京, 大阪'.encode('EUC-JP') }
+
+      it 'transcodes EUC-JP characters to UTF-8' do
+        expect(transcode(reader, line)).to eq('東京, 大阪')
+      end
+
+      it 'returns a valid UTF-8 string' do
+        result = transcode(reader, line)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.valid_encoding?).to be true
+      end
+    end
+
+    context 'UTF-16LE input (file_encoding: utf-16le)' do
+      let(:line) { 'München'.encode('UTF-16LE') }
+
+      it 'transcodes UTF-16LE characters to UTF-8' do
+        expect(transcode(reader, line)).to eq('München')
+      end
+
+      it 'returns a valid UTF-8 string' do
+        result = transcode(reader, line)
+        expect(result.encoding).to eq(Encoding::UTF_8)
+        expect(result.valid_encoding?).to be true
+      end
+    end
+
+    context 'custom invalid_byte_sequence replacement character' do
+      let(:line_utf8)    { "bad\xFF byte".dup.force_encoding('UTF-8') }
+      let(:line_iso)     { "M\xFCnchen".b.force_encoding('ISO-8859-1') }
+
+      it 'uses the specified replacement for invalid bytes in UTF-8 input' do
+        result = reader.send(:enforce_utf8_encoding, line_utf8, { invalid_byte_sequence: '?' })
+        expect(result).to eq('bad? byte')
+      end
+
+      it 'does not insert replacement for valid transcoded bytes (ISO-8859-1 → UTF-8)' do
+        result = reader.send(:enforce_utf8_encoding, line_iso, { invalid_byte_sequence: '?' })
+        expect(result).to eq('München') # ü transcodes cleanly — no replacement needed
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Transcoding pair path — file_encoding: 'ext:int'
+  #
+  # When file_encoding contains a colon (e.g. 'iso-8859-1:UTF-8'), Ruby opens
+  # the file with a transcoding pair.  @enforce_utf8 = false (string matches
+  # /utf-8/i), so enforce_utf8_encoding is NEVER called.  Instead,
+  # PeekableIO#maybe_transcode performs the ext→int conversion when replaying
+  # buffered bytes.
+  #
+  # spec/fixtures/problematic.csv is an ISO-8859-1 file with French accented
+  # characters in the header: opération, libellé, référence.
+  # ---------------------------------------------------------------------------
+  describe 'transcoding pair: file_encoding ext:int (maybe_transcode path)' do
+    let(:fixture) { 'spec/fixtures/problematic.csv' }
+    let(:accented_keys) { %w[date_opération libellé référence] }
+
+    context 'iso-8859-1:UTF-8' do
+      let(:opts) { { file_encoding: 'iso-8859-1:UTF-8', col_sep: ';', verbose: :quiet } }
+
+      it 'transcodes ISO-8859-1 headers to correctly spelled UTF-8 keys' do
+        result = SmarterCSV.process(fixture, **opts, strings_as_keys: true)
+        expect(result.first.keys).to include(*accented_keys)
+      end
+
+      it 'returns UTF-8 strings' do
+        result = SmarterCSV.process(fixture, **opts, strings_as_keys: true)
+        result.first.each_key do |k|
+          expect(k.encoding).to eq(Encoding::UTF_8)
+          expect(k.valid_encoding?).to be true
+        end
+      end
+
+      it 'parses all data rows' do
+        expect(SmarterCSV.process(fixture, **opts).length).to eq(7)
+      end
+    end
+
+    context 'windows-1252:UTF-8 (via Tempfile — same path as the iso-8859-1 test above)' do
+      # \x80 = € in Windows-1252
+      let(:csv_w1252_bytes) { "product,price\nWidget,\x80100\n".b }
+
+      it 'transcodes Windows-1252 bytes (including euro sign) to UTF-8' do
+        Tempfile.open(['w1252', '.csv']) do |f|
+          f.binmode
+          f.write(csv_w1252_bytes)
+          f.close
+          result = SmarterCSV.process(f.path, file_encoding: 'windows-1252:UTF-8', col_sep: :auto, row_sep: :auto, verbose: :quiet)
+          expect(result.first[:price]).to eq('€100')
+          expect(result.first[:price].encoding).to eq(Encoding::UTF_8)
+        end
+      end
+    end
+  end
+
   describe 'encoding warning message' do
     let(:file_path) { 'path/to/csvfile.csv' }
     let(:file_content) { "some,content\nwith,lines" }


### PR DESCRIPTION
# Work on Bugfix Release

### Bug Fixes

* Fixed bug in `SmarterCSV.errors` that could lose collected records when processing raises mid-stream,
  e.g. when `bad_row_limit:` was exceeded (`TooManyBadRows`), or when a user's block raised through `.process` / `.each` / `.each_chunk`.
  
* Fixed `enforce_utf8_encoding` incorrectly replacing all non-ASCII bytes when the input string was tagged as `ASCII-8BIT` (binary).
  The encoding is now relabeled to UTF-8 before transcoding, so only genuinely invalid byte sequences are replaced.
